### PR TITLE
Add local editorial workflow CLI for AI-assisted blog publishing

### DIFF
--- a/.blogflow/config.yaml
+++ b/.blogflow/config.yaml
@@ -1,0 +1,25 @@
+author: bnbong
+blog_dir: docs/blog/posts
+default_category: Computer Science
+
+claude:
+  model: null
+  # null = no timeout. LLM turns vary with network & post length, and the
+  # spinner already surfaces liveness; Ctrl+C is the kill switch.
+  # Set an integer (seconds) if you need a hard ceiling.
+  timeout_sec: null
+
+codex:
+  model: null
+  sandbox_review: read-only
+  sandbox_exec: workspace-write
+  # null = no timeout (see note under claude). Override with an integer if needed.
+  timeout_sec: null
+  # Override the user's global codex reasoning effort for blogflow calls.
+  # `xhigh` can take 10+ minutes on a full-draft review; `medium` is the
+  # pragmatic default. Set to null to defer to ~/.codex/config.toml.
+  reasoning_effort: medium
+
+publish:
+  update_updated_date: true
+  ensure_draft_false: true

--- a/.blogflow/prompts/README.md
+++ b/.blogflow/prompts/README.md
@@ -1,0 +1,5 @@
+# blogflow prompt overrides
+
+Drop a file named `<stage>.md.j2` here (e.g. `brief.md.j2`, `review.md.j2`) to override the package default for that stage. Templates are Jinja2; the session context object is injected as `session`, `brief`, `answers`, `draft`, `review`, `reflection`, and `repo`.
+
+If a file is missing here, the packaged template under `blogflow/prompts_tpl/` is used.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 venv/
 .cache
 site/
+.blogflow/sessions/
+.blogflow/ideas/
+tools/blogflow/build/
+tools/blogflow/dist/
+tools/blogflow/*.egg-info/
 env*
 .env
 .vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ virtualenv==20.28.0
 watchdog==6.0.0
 webencodings==0.5.1
 beautifulsoup4==4.12.3
+pytest==8.3.3

--- a/tools/blogflow/README.md
+++ b/tools/blogflow/README.md
@@ -1,0 +1,21 @@
+# blogflow
+
+Local editorial workflow CLI for `bnbong.github.io` — orchestrates `claude` and `codex` CLIs through an approval-gated writing pipeline.
+
+See [blogflow-cli-project-plan.md](./blogflow-cli-project-plan.md) for the product philosophy.
+
+## Install
+
+```bash
+pip install -e tools/blogflow
+```
+
+Then `blogflow --help` from anywhere in the repo.
+
+## Workflow at a glance
+
+```
+ideas → init → brief → answer → draft → review → reflection → finalize → approve → publish
+```
+
+Every stage persists artifacts to `.blogflow/sessions/<id>/`. No publish without explicit `blogflow approve`.

--- a/tools/blogflow/blogflow-cli-project-plan.md
+++ b/tools/blogflow/blogflow-cli-project-plan.md
@@ -1,0 +1,632 @@
+# blogflow CLI Project Plan
+
+## 1. Overview
+
+`blogflow` is a local-first editorial workflow CLI for writing technical blog posts with strong human supervision.
+
+The purpose of the tool is **not** to let AI fully author and publish posts autonomously. Instead, it should help the author:
+
+- choose or refine topics,
+- gather and approve sources,
+- review concept summaries before drafting,
+- lock the writing scope and post structure,
+- draft posts with source-aware constraints,
+- run a second-model review before publishing,
+- optionally add a personal reflection section,
+- require explicit human approval before publish.
+
+This plan is based on the full discussion history for the project, including:
+
+- the desire to publish steadily at a pace of roughly 2-3 posts per week,
+- the requirement that the author remain deeply involved in topic selection, concept validation, structure, and final approval,
+- the need to reduce hallucination risk as much as possible for technical writing,
+- the preference for attaching external references when appropriate,
+- the requirement that the final "reflection" section remain optional,
+- the available local environment: macOS, `claude` CLI installed, `codex` CLI installed.
+
+## 2. Problem Statement
+
+The current blog workflow is good for manual writing, but it does not provide a structured editorial system for:
+
+- topic backlog management,
+- source approval,
+- human-in-the-loop concept review,
+- claim tracking,
+- multi-model review,
+- approval-gated publishing,
+- repeatable local execution.
+
+Without structure, consistent publication becomes difficult. Without source controls, technical post quality becomes vulnerable to LLM hallucination and overconfident simplification.
+
+## 3. Goals
+
+### Primary goals
+
+- Build a repeatable local CLI workflow for technical blog writing.
+- Keep the author in control of concept, scope, flow, and publishing.
+- Use AI for summarization, drafting, and review support.
+- Reduce hallucination risk using explicit workflow gates.
+- Make the workflow practical enough to support 2-3 posts per week.
+
+### Secondary goals
+
+- Reuse the workflow across different post types:
+  - concept explainers,
+  - project retrospectives,
+  - troubleshooting notes,
+  - OSS contribution records.
+- Preserve intermediate artifacts for later inspection and revision.
+- Support topic suggestion as well as author-driven topic selection.
+
+## 4. Non-Goals
+
+- No fully autonomous publishing.
+- No background daemon, server, or hosted workflow engine.
+- No web dashboard or GUI in the MVP.
+- No mandatory Git push automation in the MVP.
+- No multi-user collaboration features.
+- No attempt to mathematically guarantee zero hallucination. Instead, the workflow must make unsupported claims visible and block them from publish readiness.
+
+## 5. Constraints
+
+### Editorial constraints
+
+- Technical posts require source-aware writing.
+- The author wants to review summarized concepts before drafting.
+- The author wants AI to ask focused questions only when human judgment is genuinely needed.
+- The "reflection" or "what I learned" section must be optional.
+- Final publishing must require explicit human approval.
+
+### Environment constraints
+
+- The tool will run only on the author's local MacBook (macOS).
+- Local tools already available:
+  - `claude`
+  - `codex`
+- The repository is a MkDocs-based blog with posts under `docs/blog/posts/...`.
+- `n8n` is intentionally not part of the solution.
+
+## 6. Core Product Philosophy
+
+`blogflow` is a **local editorial orchestrator**, not an autonomous author.
+
+It should behave like a careful assistant that:
+
+- organizes workflow state,
+- invokes Claude and Codex when needed,
+- stores prompts, outputs, and user decisions,
+- enforces gates before advancing,
+- makes the author's involvement lightweight but meaningful.
+
+## 7. Human and AI Roles
+
+### Author
+
+The author is responsible for:
+
+- selecting or approving the topic,
+- approving the source pack,
+- answering scope and audience questions,
+- reviewing the outline direction,
+- approving the final draft,
+- optionally writing personal reflection input,
+- approving publish.
+
+### Claude
+
+Claude acts as the **editorial director and primary drafter**:
+
+- topic recommendation,
+- brief generation,
+- source pack suggestion,
+- question generation,
+- outline generation,
+- first-pass drafting,
+- optional reflection prompting,
+- revision support after review.
+
+### Codex
+
+Codex acts as the **technical review and publish gate checker**:
+
+- identify unsupported or weakly supported claims,
+- detect over-simplifications,
+- flag terminology risk,
+- check structure and repository-fit,
+- inspect factual and wording risks before publish.
+
+## 8. Hallucination Control Strategy
+
+The workflow must reduce hallucination risk by process, not by trust.
+
+### Required mechanisms
+
+- **Source gate**: approved source set before drafting.
+- **Brief gate**: author reviews the conceptual summary before draft generation.
+- **Question gate**: AI asks focused questions to resolve scope ambiguity.
+- **Claim awareness**: draft generation should surface key factual claims and uncertain areas.
+- **Second-model review**: Codex reviews Claude output before finalization.
+- **Approval gate**: no publish without explicit human approval.
+
+### Operational principle
+
+The workflow should treat unsupported claims as workflow defects, not stylistic noise.
+
+## 9. Supported Post Entry Modes
+
+`blogflow` must support two ways to begin:
+
+### Author-selected topic
+
+The author provides the topic directly.
+
+Examples:
+
+- IPv4 concept explainer
+- FastAPI FastKit design lessons
+- K-Buddy infra retrospective
+
+### AI-suggested topic
+
+Claude proposes topics based on:
+
+- recent repo/project activity,
+- open project material,
+- recurring study themes,
+- gaps in existing blog coverage,
+- author experience likely to produce high-value posts.
+
+Each topic suggestion should ideally include:
+
+- title idea,
+- why now,
+- intended audience,
+- expected difficulty,
+- source requirements,
+- hallucination risk,
+- whether the topic is suitable for a single post or a series.
+
+## 10. End-to-End Workflow
+
+### Workflow summary
+
+1. Topic selection
+2. Session initialization
+3. Source pack generation
+4. Brief generation
+5. User answers / scope decisions
+6. Outline generation
+7. Draft generation
+8. Codex review
+9. Draft revision
+10. Optional reflection
+11. Finalization
+12. Approval
+13. Publish
+
+### Reflection rule
+
+Reflection is optional:
+
+- if the author answers the reflection prompt, include the section,
+- if the author skips or leaves it empty, do not create the section.
+
+## 11. Status Machine
+
+Each post session should move through an explicit status machine.
+
+Recommended states:
+
+- `initiated`
+- `brief_ready`
+- `awaiting_answers`
+- `draft_ready`
+- `under_review`
+- `awaiting_reflection`
+- `final_ready`
+- `approved`
+- `published`
+
+Illegal transitions should be blocked.
+
+Examples:
+
+- no review before a draft exists,
+- no finalize before review,
+- no publish before approval.
+
+## 12. Recommended Session Artifact Layout
+
+Each session should be stored in a dedicated folder under `.blogflow/`.
+
+```text
+.blogflow/
+  config.yaml
+  sessions/
+    <session-id>/
+      session.yaml
+      prompts/
+        brief.txt
+        draft.txt
+        review.txt
+        finalize.txt
+        reflection.txt
+      outputs/
+        brief.json
+        draft.md
+        review.md
+        final.md
+      user/
+        answers.yaml
+        reflection.md
+      schemas/
+        brief.schema.json
+        draft.schema.json
+        review.schema.json
+```
+
+This layout must support:
+
+- reproducibility,
+- restartability,
+- auditability,
+- debugging prompt quality later.
+
+## 13. CLI Command Set (MVP)
+
+The MVP command set should be:
+
+- `blogflow ideas`
+- `blogflow init`
+- `blogflow status`
+- `blogflow brief`
+- `blogflow answer`
+- `blogflow draft`
+- `blogflow review`
+- `blogflow reflection`
+- `blogflow finalize`
+- `blogflow approve`
+- `blogflow publish`
+
+### Command intent
+
+#### `blogflow ideas`
+
+- ask Claude to propose topic candidates,
+- optionally scoped by category or difficulty,
+- store or print candidates.
+
+#### `blogflow init`
+
+- start a session for a specific post or topic,
+- create session folder and metadata,
+- bind target post path if already known.
+
+#### `blogflow status`
+
+- show current status,
+- show existing artifacts,
+- suggest next valid command.
+
+#### `blogflow brief`
+
+- invoke Claude with the briefing prompt,
+- generate:
+  - one-line goal,
+  - learning brief,
+  - source pack proposal,
+  - scope,
+  - questions,
+  - outline v1,
+  - claim categories,
+- persist outputs.
+
+#### `blogflow answer`
+
+- capture author decisions from the brief stage,
+- update session metadata and answer artifacts.
+
+#### `blogflow draft`
+
+- invoke Claude to generate:
+  - title candidates,
+  - description candidates,
+  - first draft,
+  - claim summary,
+  - references draft,
+  - known risks for Codex review.
+
+#### `blogflow review`
+
+- invoke Codex to review the draft,
+- produce findings and gate decision,
+- flag unsupported claims or risky wording.
+
+#### `blogflow reflection`
+
+- optionally ask the author reflection questions,
+- persist response if provided,
+- allow clean skip.
+
+#### `blogflow finalize`
+
+- combine:
+  - draft,
+  - review feedback,
+  - optional reflection,
+- generate final candidate output,
+- keep publish blocked until approval.
+
+#### `blogflow approve`
+
+- record explicit human approval in session state.
+
+#### `blogflow publish`
+
+- write final content into target post file,
+- ensure `draft: false`,
+- update `date.updated`,
+- print suggested Git commands,
+- do not auto-push in MVP.
+
+## 14. Integration with Claude and Codex
+
+### Claude invocation
+
+Prefer structured non-interactive execution.
+
+Recommended direction:
+
+- `claude -p`
+- `--output-format json`
+- `--json-schema ...`
+
+Fallback:
+
+- raw text output saved to artifact files when structured output is unavailable.
+
+### Codex invocation
+
+Prefer non-interactive execution and review mode.
+
+Possible direction:
+
+- `codex exec --output-schema ...`
+- `codex review ...` when the interaction maps naturally to review semantics
+
+### Adapter rule
+
+LLM invocation must be isolated behind adapter modules so that:
+
+- prompt logic stays separate from transport,
+- retries and fallback behavior can be added later,
+- tests can mock process execution cleanly.
+
+## 15. Prompt Strategy
+
+Prompt design should be modular and stage-specific.
+
+Required prompt categories:
+
+- ideas prompt
+- brief prompt
+- draft prompt
+- review prompt
+- finalize prompt
+- reflection prompt
+
+Prompt builders should accept session context instead of hardcoding a single topic.
+
+The IPv4 post used during planning should serve as one concrete example, not a special case baked into business logic.
+
+## 16. Publish Safety Rules
+
+The tool must be conservative at publish time.
+
+### Required checks before publish
+
+- final artifact exists,
+- session status is `approved`,
+- target post path is defined,
+- frontmatter remains valid,
+- `draft: false` will be applied,
+- `date.updated` will be refreshed,
+- final output is present on disk.
+
+### Explicitly out of scope for MVP
+
+- automatic Git commit,
+- automatic Git push,
+- automatic GitHub deployment.
+
+The tool may print recommended next commands such as:
+
+```bash
+git add <post-path> .blogflow/sessions/<session-id>
+git commit -m "Add IPv4 blog post draft"
+git push origin main
+```
+
+## 17. UX Expectations
+
+The CLI should be practical and calm, not overly magical.
+
+Each command should:
+
+- explain what it did,
+- list generated files,
+- show current status,
+- suggest the next likely command.
+
+Errors should be actionable.
+
+Examples:
+
+- "Cannot run review before draft generation."
+- "Cannot publish before approval."
+- "Brief exists but answers are missing. Run `blogflow answer` next."
+
+## 18. Recommended Implementation Shape
+
+### Language
+
+- Python
+
+### Recommended libraries
+
+- `click`
+- `PyYAML`
+- standard library `subprocess`
+- optional `Jinja2` for prompt templating
+
+### Recommended module layout
+
+```text
+tools/blogflow/
+  cli.py
+  state.py
+  models.py
+  prompts.py
+  frontmatter.py
+  publish.py
+  schemas.py
+  adapters/
+    claude.py
+    codex.py
+```
+
+### Design rules
+
+- small modules,
+- testable logic,
+- no monolithic command handler,
+- clear separation between:
+  - workflow state,
+  - prompt generation,
+  - LLM process execution,
+  - post file mutation.
+
+## 19. Testing Strategy
+
+The MVP should include tests for:
+
+- session creation,
+- state transitions,
+- invalid state transition blocking,
+- frontmatter read/write,
+- publish mutation safety,
+- prompt artifact creation,
+- adapter mocking for Claude and Codex calls.
+
+Tests should not depend on real LLM execution.
+
+## 20. Phased Delivery Plan
+
+### Phase 1: MVP
+
+- implement all listed commands,
+- session state management,
+- prompt/output artifact storage,
+- Claude draft flow,
+- Codex review flow,
+- approval-gated publish.
+
+### Phase 2: Quality improvements
+
+- richer source pack support,
+- stronger claim artifact structure,
+- prompt externalization,
+- improved schema validation,
+- reusable prompt presets by post type.
+
+### Phase 3: Convenience features
+
+- git helper commands,
+- topic backlog view,
+- stronger repo introspection,
+- scheduling helpers,
+- template presets for:
+  - explainer,
+  - project retrospective,
+  - troubleshooting note,
+  - OSS contribution post.
+
+## 21. Risks and Mitigations
+
+### Risk: LLM output inconsistency
+
+Mitigation:
+
+- structured output where possible,
+- save raw prompts and outputs,
+- allow rerun of any stage.
+
+### Risk: hidden hallucinations in technically familiar topics
+
+Mitigation:
+
+- source pack requirement,
+- Codex review gate,
+- manual approval.
+
+### Risk: too much friction to sustain weekly writing
+
+Mitigation:
+
+- keep commands short,
+- preserve intermediate state,
+- allow lite usage for simple posts,
+- reserve stricter review for high-risk posts.
+
+### Risk: publish becomes too automated
+
+Mitigation:
+
+- no publish without explicit approval,
+- no automatic push in MVP.
+
+## 22. Acceptance Criteria
+
+The project can be considered successful when:
+
+- the author can run the workflow entirely on local macOS,
+- a new session can be created for a post like `IPv4`,
+- Claude can generate a brief and first draft through `blogflow`,
+- Codex can review the draft through `blogflow`,
+- the author can skip reflection cleanly,
+- the author must explicitly approve before publish,
+- publish writes the final post content safely without automatically pushing Git changes,
+- all intermediate artifacts are saved and inspectable.
+
+## 23. Example Success Case: IPv4 Post
+
+Example target:
+
+- file: `docs/blog/posts/20250117-computer-network-3/20250117.md`
+- topic: `IPv4`
+- workflow:
+  - init session,
+  - generate brief and source pack,
+  - answer scope questions,
+  - generate draft,
+  - run Codex review,
+  - revise/finalize,
+  - optionally skip reflection,
+  - approve,
+  - publish.
+
+If that flow works end-to-end with saved artifacts and no unsafe automation, the MVP is functionally validated.
+
+## 24. Final Recommendation
+
+`blogflow` should be implemented as a **local Python CLI application**.
+
+That is the best fit because:
+
+- the workflow is stateful,
+- the author is on macOS only,
+- both `claude` and `codex` CLIs already exist locally,
+- the problem is orchestration and safety, not hosting,
+- the author wants strong human supervision and artifact visibility.
+
+This means the next practical step is to hand this plan and the implementation prompt to Claude Opus 4.7 and ask it to build the MVP inside the repository.

--- a/tools/blogflow/blogflow/__init__.py
+++ b/tools/blogflow/blogflow/__init__.py
@@ -1,0 +1,3 @@
+"""blogflow — local editorial workflow CLI."""
+
+__version__ = "0.1.0"

--- a/tools/blogflow/blogflow/adapters/__init__.py
+++ b/tools/blogflow/blogflow/adapters/__init__.py
@@ -1,0 +1,7 @@
+"""LLM adapters (Claude / Codex)."""
+
+from .base import AdapterResult, LLMAdapter
+from .claude import ClaudeAdapter
+from .codex import CodexAdapter
+
+__all__ = ["AdapterResult", "LLMAdapter", "ClaudeAdapter", "CodexAdapter"]

--- a/tools/blogflow/blogflow/adapters/base.py
+++ b/tools/blogflow/blogflow/adapters/base.py
@@ -83,9 +83,11 @@ def invoke(
             cmd=cmd,
             exit_code=-1,
             duration_ms=duration,
-            stdout=exc.stdout.decode()
-            if isinstance(exc.stdout, bytes)
-            else (exc.stdout or ""),
+            stdout=(
+                exc.stdout.decode()
+                if isinstance(exc.stdout, bytes)
+                else (exc.stdout or "")
+            ),
             stderr=f"TIMEOUT after {effective_timeout}s",
         )
         raise
@@ -142,9 +144,7 @@ class _Spinner:
             elapsed = int(time.monotonic() - start)
             mins, secs = divmod(elapsed, 60)
             try:
-                sys.stderr.write(
-                    f"\r{next(frames)} {self._label}  {mins}:{secs:02d}"
-                )
+                sys.stderr.write(f"\r{next(frames)} {self._label}  {mins}:{secs:02d}")
                 sys.stderr.flush()
             except Exception:
                 return

--- a/tools/blogflow/blogflow/adapters/base.py
+++ b/tools/blogflow/blogflow/adapters/base.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol
 
+from ..errors import AdapterError
+
 
 @dataclass
 class AdapterResult:
@@ -91,6 +93,28 @@ def invoke(
             stderr=f"TIMEOUT after {effective_timeout}s",
         )
         raise
+    except FileNotFoundError as exc:
+        # argv[0] missing on PATH — without this catch, subprocess.run raises
+        # FileNotFoundError straight through the adapter and the CLI prints a
+        # full Python traceback. Convert to AdapterError so users see an
+        # actionable install hint instead. First-run UX on machines without
+        # both `claude` and `codex` preinstalled broke without this.
+        spinner.stop()
+        duration = int((time.monotonic() - start) * 1000)
+        binary = cmd[0] if cmd else adapter_name
+        msg = (
+            f"{adapter_name} binary {binary!r} not found on PATH. "
+            f"Install the CLI and re-run, or set a custom path in .blogflow/config.yaml."
+        )
+        _write_log(
+            log_path,
+            cmd=cmd,
+            exit_code=-1,
+            duration_ms=duration,
+            stdout="",
+            stderr=f"{type(exc).__name__}: {exc}",
+        )
+        raise AdapterError(msg) from exc
     finally:
         spinner.stop()
     duration = int((time.monotonic() - start) * 1000)

--- a/tools/blogflow/blogflow/adapters/base.py
+++ b/tools/blogflow/blogflow/adapters/base.py
@@ -1,0 +1,172 @@
+"""Adapter protocol + shared invocation helpers."""
+
+from __future__ import annotations
+
+import itertools
+import os
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+
+@dataclass
+class AdapterResult:
+    ok: bool
+    text: str
+    parsed: dict | None = None
+    stderr: str = ""
+    cmd: list[str] = field(default_factory=list)
+    duration_ms: int = 0
+    exit_code: int = 0
+
+
+class LLMAdapter(Protocol):
+    name: str
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        schema: dict | None = None,
+        log_dir: Path,
+        stage: str,
+        extra: dict[str, Any] | None = None,
+    ) -> AdapterResult: ...
+
+
+def invoke(
+    cmd: list[str],
+    *,
+    stdin_text: str | None,
+    timeout_sec: int | None,
+    log_dir: Path,
+    stage: str,
+    adapter_name: str,
+) -> tuple[subprocess.CompletedProcess, int]:
+    """Run subprocess, persist log, return process + duration_ms.
+
+    ``timeout_sec=None`` (or ``0``) disables the timeout entirely — the
+    default for blogflow, since LLM turns vary wildly with network and post
+    length, and a stuck process can always be killed with Ctrl+C.
+
+    While the subprocess runs, show an elapsed-time spinner on stderr so the
+    user knows the CLI is alive during multi-minute LLM calls. The spinner
+    is suppressed when stderr isn't a TTY (tests, pipelines, redirected runs).
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_path = log_dir / f"{stage}-{adapter_name}-{ts}.log"
+    start = time.monotonic()
+    spinner = _Spinner(f"{stage} · {adapter_name}")
+    spinner.start()
+    effective_timeout = timeout_sec if timeout_sec else None
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            timeout=effective_timeout,
+            check=False,
+            env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        spinner.stop()
+        duration = int((time.monotonic() - start) * 1000)
+        _write_log(
+            log_path,
+            cmd=cmd,
+            exit_code=-1,
+            duration_ms=duration,
+            stdout=exc.stdout.decode()
+            if isinstance(exc.stdout, bytes)
+            else (exc.stdout or ""),
+            stderr=f"TIMEOUT after {effective_timeout}s",
+        )
+        raise
+    finally:
+        spinner.stop()
+    duration = int((time.monotonic() - start) * 1000)
+    _write_log(
+        log_path,
+        cmd=cmd,
+        exit_code=proc.returncode,
+        duration_ms=duration,
+        stdout=proc.stdout or "",
+        stderr=proc.stderr or "",
+    )
+    return proc, duration
+
+
+class _Spinner:
+    """Background thread that prints an elapsed-time spinner on stderr.
+
+    No-ops when stderr is not a TTY so it stays invisible in tests, CI, and
+    piped runs. Uses a carriage return to stay on a single line.
+    """
+
+    _FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def __init__(self, label: str):
+        self._label = label
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._active = sys.stderr.isatty()
+
+    def start(self) -> None:
+        if not self._active:
+            return
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if not self._active or self._thread is None:
+            return
+        self._stop.set()
+        self._thread.join(timeout=0.5)
+        try:
+            sys.stderr.write("\r" + " " * 80 + "\r")
+            sys.stderr.flush()
+        except Exception:
+            pass
+
+    def _loop(self) -> None:
+        frames = itertools.cycle(self._FRAMES)
+        start = time.monotonic()
+        while not self._stop.is_set():
+            elapsed = int(time.monotonic() - start)
+            mins, secs = divmod(elapsed, 60)
+            try:
+                sys.stderr.write(
+                    f"\r{next(frames)} {self._label}  {mins}:{secs:02d}"
+                )
+                sys.stderr.flush()
+            except Exception:
+                return
+            self._stop.wait(0.12)
+
+
+def _write_log(
+    path: Path,
+    *,
+    cmd: list[str],
+    exit_code: int,
+    duration_ms: int,
+    stdout: str,
+    stderr: str,
+) -> None:
+    lines = [
+        f"# cmd: {cmd}",
+        f"# exit_code: {exit_code}",
+        f"# duration_ms: {duration_ms}",
+        "## stdout",
+        stdout,
+        "## stderr",
+        stderr,
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")

--- a/tools/blogflow/blogflow/adapters/claude.py
+++ b/tools/blogflow/blogflow/adapters/claude.py
@@ -1,0 +1,146 @@
+"""Claude CLI adapter.
+
+Invokes ``claude -p --output-format json [--json-schema <inline-json>]``,
+feeding the rendered prompt through stdin. The ``--json-schema`` flag accepts
+the schema JSON inline (not a file path). The JSON envelope's ``result``
+field is extracted; when a schema is supplied and the result is valid JSON,
+it is also returned in ``parsed``. All failures are captured in the returned
+``AdapterResult`` so callers can decide whether to retry or surface the error.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..errors import AdapterError
+from .base import AdapterResult, invoke
+
+
+@dataclass
+class ClaudeAdapter:
+    name: str = "claude"
+    binary: str = "claude"
+    model: str | None = None
+    # None = no timeout. Overridable via config / per-call ``extra["timeout_sec"]``.
+    timeout_sec: int | None = None
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        schema: dict | None = None,
+        log_dir: Path,
+        stage: str,
+        extra: dict[str, Any] | None = None,
+    ) -> AdapterResult:
+        extra = extra or {}
+        cmd: list[str] = [self.binary, "-p", "--output-format", "json"]
+        if self.model:
+            cmd.extend(["--model", self.model])
+
+        if schema is not None:
+            cmd.extend(["--json-schema", json.dumps(schema, ensure_ascii=False)])
+
+        for flag in extra.get("extra_args", []) or []:
+            cmd.append(str(flag))
+
+        timeout = _coerce_timeout(extra.get("timeout_sec", self.timeout_sec))
+
+        try:
+            proc, duration_ms = invoke(
+                cmd,
+                stdin_text=prompt,
+                timeout_sec=timeout,
+                log_dir=log_dir,
+                stage=stage,
+                adapter_name=self.name,
+            )
+        except subprocess.TimeoutExpired:
+            return AdapterResult(
+                ok=False,
+                text="",
+                stderr=f"TIMEOUT after {timeout}s",
+                cmd=cmd,
+                exit_code=-1,
+            )
+
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+        text, parsed = _extract_result(stdout, expects_json=schema is not None)
+
+        ok = proc.returncode == 0 and bool(text)
+        return AdapterResult(
+            ok=ok,
+            text=text or stdout,
+            parsed=parsed,
+            stderr=stderr,
+            cmd=cmd,
+            duration_ms=duration_ms,
+            exit_code=proc.returncode,
+        )
+
+
+def _extract_result(stdout: str, *, expects_json: bool) -> tuple[str, dict | None]:
+    """Parse the claude envelope.
+
+    The CLI emits a JSON object. With ``--json-schema`` the validated payload
+    arrives under ``structured_output`` (and ``result`` is empty). Without a
+    schema, the free-form text lives in ``result``.
+    """
+    stripped = stdout.strip()
+    if not stripped:
+        return "", None
+    try:
+        envelope = json.loads(stripped)
+    except json.JSONDecodeError:
+        return stripped, None
+
+    if expects_json and isinstance(envelope, dict):
+        structured = envelope.get("structured_output")
+        if isinstance(structured, dict):
+            return json.dumps(structured, ensure_ascii=False), structured
+        if isinstance(structured, str):
+            try:
+                parsed = json.loads(structured)
+            except json.JSONDecodeError:
+                return structured, None
+            if isinstance(parsed, dict):
+                return structured, parsed
+            return structured, None
+
+    if isinstance(envelope, dict) and "result" in envelope:
+        result = envelope["result"]
+    else:
+        result = envelope
+
+    if isinstance(result, dict):
+        return json.dumps(result, ensure_ascii=False), result
+    if isinstance(result, str):
+        if expects_json:
+            try:
+                parsed = json.loads(result)
+            except json.JSONDecodeError:
+                return result, None
+            if isinstance(parsed, dict):
+                return result, parsed
+            return result, None
+        return result, None
+    return json.dumps(result, ensure_ascii=False), None
+
+
+def require_binary(binary: str) -> None:
+    from shutil import which
+
+    if which(binary) is None:
+        raise AdapterError(f"{binary!r} not found on PATH.")
+
+
+def _coerce_timeout(value: Any) -> int | None:
+    """Accept int/str/None and map falsy values to "no timeout"."""
+    if value in (None, "", 0, "0"):
+        return None
+    return int(value)

--- a/tools/blogflow/blogflow/adapters/codex.py
+++ b/tools/blogflow/blogflow/adapters/codex.py
@@ -1,0 +1,124 @@
+"""Codex CLI adapter.
+
+Shells out to ``codex exec`` for both draft generation and review. Codex has no
+native JSON-schema mode, so prompts must end with a ``GATE: APPROVED|REVISE|BLOCK``
+marker when a decision is needed; parsing that marker is the caller's job — the
+adapter only returns the raw text.
+
+``mode`` in ``extra`` controls which sandbox is used:
+
+- ``"exec"`` (default) — ``sandbox_exec`` (``workspace-write``), used for any
+  write-enabled stage.
+- ``"review"`` — ``sandbox_review`` (``read-only``), used for factual-check
+  stages that must not mutate the workspace.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .base import AdapterResult, invoke
+
+
+@dataclass
+class CodexAdapter:
+    name: str = "codex"
+    binary: str = "codex"
+    model: str | None = None
+    sandbox_exec: str = "workspace-write"
+    sandbox_review: str = "read-only"
+    # None = no timeout. Overridable via config / per-call ``extra["timeout_sec"]``.
+    timeout_sec: int | None = None
+    # Codex respects the user's `~/.codex/config.toml` reasoning effort, which
+    # defaults to `xhigh` on many installs and makes a full-draft review run
+    # 10+ minutes. Blogflow overrides this per-invocation to keep review and
+    # draft turns interactive; users can raise it via config if needed.
+    reasoning_effort: str | None = "medium"
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        schema: dict | None = None,
+        log_dir: Path,
+        stage: str,
+        extra: dict[str, Any] | None = None,
+    ) -> AdapterResult:
+        extra = extra or {}
+        mode = extra.get("mode", "exec")
+        sandbox = extra.get(
+            "sandbox",
+            self.sandbox_review if mode == "review" else self.sandbox_exec,
+        )
+
+        cmd: list[str] = [self.binary, "exec", "-s", str(sandbox)]
+        if self.model:
+            cmd.extend(["--model", self.model])
+
+        effort = extra.get("reasoning_effort", self.reasoning_effort)
+        if effort:
+            cmd.extend(["-c", f"model_reasoning_effort={effort}"])
+
+        for flag in extra.get("extra_args", []) or []:
+            cmd.append(str(flag))
+
+        timeout = _coerce_timeout(extra.get("timeout_sec", self.timeout_sec))
+
+        try:
+            proc, duration_ms = invoke(
+                cmd,
+                stdin_text=prompt,
+                timeout_sec=timeout,
+                log_dir=log_dir,
+                stage=stage,
+                adapter_name=self.name,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return AdapterResult(
+                ok=False,
+                text=(exc.stdout or "") if isinstance(exc.stdout, str) else "",
+                stderr=f"TIMEOUT after {timeout}s",
+                cmd=cmd,
+                exit_code=-1,
+            )
+
+        stdout = proc.stdout or ""
+        stderr = proc.stderr or ""
+        ok = proc.returncode == 0 and bool(stdout.strip())
+        return AdapterResult(
+            ok=ok,
+            text=stdout,
+            parsed=None,
+            stderr=stderr,
+            cmd=cmd,
+            duration_ms=duration_ms,
+            exit_code=proc.returncode,
+        )
+
+
+GATE_APPROVED = "APPROVED"
+GATE_REVISE = "REVISE"
+GATE_BLOCK = "BLOCK"
+GATE_UNCLEAR = "UNCLEAR"
+
+
+def parse_gate(text: str) -> str:
+    """Find the last ``GATE:`` marker in the text and return the decision."""
+    last: str | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.upper().startswith("GATE:"):
+            last = stripped.split(":", 1)[1].strip().upper()
+    if last in {GATE_APPROVED, GATE_REVISE, GATE_BLOCK}:
+        return last
+    return GATE_UNCLEAR
+
+
+def _coerce_timeout(value: Any) -> int | None:
+    """Accept int/str/None and map falsy values to "no timeout"."""
+    if value in (None, "", 0, "0"):
+        return None
+    return int(value)

--- a/tools/blogflow/blogflow/cli.py
+++ b/tools/blogflow/blogflow/cli.py
@@ -1,0 +1,58 @@
+"""Click entrypoint for the `blogflow` CLI."""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+from . import __version__
+from .commands.answer import answer_cmd
+from .commands.approve import approve_cmd
+from .commands.brief import brief_cmd
+from .commands.draft import draft_cmd
+from .commands.finalize import finalize_cmd
+from .commands.ideas import ideas_cmd
+from .commands.init import init_cmd
+from .commands.publish import publish_cmd
+from .commands.reflection import reflection_cmd
+from .commands.review import review_cmd
+from .commands.status import status_cmd
+from .errors import BlogflowError
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(__version__, "-V", "--version")
+def cli() -> None:
+    """Local-first editorial workflow for bnbong.github.io."""
+
+
+for _cmd in (
+    ideas_cmd,
+    init_cmd,
+    status_cmd,
+    brief_cmd,
+    answer_cmd,
+    draft_cmd,
+    review_cmd,
+    reflection_cmd,
+    finalize_cmd,
+    approve_cmd,
+    publish_cmd,
+):
+    cli.add_command(_cmd)
+
+
+def main() -> None:
+    try:
+        cli(standalone_mode=True)
+    except BlogflowError as exc:
+        click.echo(f"error: {exc}", err=True)
+        hint = getattr(exc, "expected_command", None)
+        if hint:
+            click.echo(f"hint: next expected — {hint}", err=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/blogflow/blogflow/commands/__init__.py
+++ b/tools/blogflow/blogflow/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CLI sub-command modules."""

--- a/tools/blogflow/blogflow/commands/_context.py
+++ b/tools/blogflow/blogflow/commands/_context.py
@@ -1,0 +1,151 @@
+"""Shared helpers: repo/config/session/adapter wiring for command handlers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..adapters.claude import ClaudeAdapter
+from ..adapters.codex import CodexAdapter
+from ..errors import ConfigError
+from ..state import (
+    NEXT_COMMAND_HINT,
+    Session,
+    SessionStore,
+    find_repo_root,
+    load_config,
+)
+
+
+@dataclass
+class Context:
+    repo_root: Path
+    config: dict[str, Any]
+    store: SessionStore
+
+    def recent_post_titles(self, limit: int = 10) -> list[str]:
+        blog_dir = self.repo_root / self.config.get("blog_dir", "docs/blog/posts")
+        if not blog_dir.exists():
+            return []
+        titles: list[str] = []
+        for md in sorted(blog_dir.rglob("*.md"), reverse=True):
+            try:
+                text = md.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            if not text.startswith("---"):
+                continue
+            try:
+                parts = text.split("---", 2)
+                meta = yaml.safe_load(parts[1]) or {}
+            except Exception:
+                continue
+            t = meta.get("title")
+            if isinstance(t, str):
+                titles.append(t)
+            if len(titles) >= limit:
+                break
+        return titles
+
+    def author(self) -> str:
+        return str(self.config.get("author", "author"))
+
+    def default_category(self) -> str:
+        return str(self.config.get("default_category", "General"))
+
+    def claude_adapter(self) -> ClaudeAdapter:
+        cfg = self.config.get("claude") or {}
+        return ClaudeAdapter(
+            model=cfg.get("model"),
+            timeout_sec=_optional_timeout(cfg.get("timeout_sec")),
+        )
+
+    def codex_adapter(self) -> CodexAdapter:
+        cfg = self.config.get("codex") or {}
+        adapter = CodexAdapter(
+            model=cfg.get("model"),
+            sandbox_exec=str(cfg.get("sandbox_exec", "workspace-write")),
+            sandbox_review=str(cfg.get("sandbox_review", "read-only")),
+            timeout_sec=_optional_timeout(cfg.get("timeout_sec")),
+        )
+        if "reasoning_effort" in cfg:
+            effort = cfg.get("reasoning_effort")
+            adapter.reasoning_effort = None if effort in (None, "") else str(effort)
+        return adapter
+
+
+def build_context(start: Path | None = None) -> Context:
+    repo_root = find_repo_root(start)
+    config = _load_config_or_default(repo_root)
+    store = SessionStore(repo_root)
+    return Context(repo_root=repo_root, config=config, store=store)
+
+
+def _load_config_or_default(repo_root: Path) -> dict[str, Any]:
+    try:
+        return load_config(repo_root)
+    except ConfigError:
+        return {
+            "author": "author",
+            "blog_dir": "docs/blog/posts",
+            "default_category": "General",
+            "claude": {"timeout_sec": None},
+            "codex": {
+                "sandbox_review": "read-only",
+                "sandbox_exec": "workspace-write",
+                "timeout_sec": None,
+            },
+            "publish": {"update_updated_date": True, "ensure_draft_false": True},
+        }
+
+
+def _optional_timeout(value: Any) -> int | None:
+    """Config may supply ``null``, 0, missing — all mean "no timeout"."""
+    if value in (None, "", 0, "0"):
+        return None
+    return int(value)
+
+
+def session_rel_path(ctx: Context, session: Session) -> str:
+    return f".blogflow/sessions/{session.id}"
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ConfigError(f"{path} must be a YAML mapping.")
+    return data
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def next_hint(status: str) -> str:
+    return NEXT_COMMAND_HINT.get(status, "(unknown)")
+
+
+def write_prompt(session_dir: Path, stage: str, prompt: str) -> Path:
+    out = session_dir / "prompts" / f"{stage}.txt"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(prompt, encoding="utf-8")
+    return out

--- a/tools/blogflow/blogflow/commands/_context.py
+++ b/tools/blogflow/blogflow/commands/_context.py
@@ -39,8 +39,14 @@ class Context:
                 continue
             if not text.startswith("---"):
                 continue
+            parts = text.split("---", 2)
+            # A valid frontmatter block has opening fence, body, closing fence
+            # → three parts after splitting with maxsplit=2. Skip anything
+            # shorter (e.g. file that opens `---` but never closes it) instead
+            # of silently picking up whatever YAML-parses from the opener.
+            if len(parts) < 3:
+                continue
             try:
-                parts = text.split("---", 2)
                 meta = yaml.safe_load(parts[1]) or {}
             except Exception:
                 continue
@@ -86,9 +92,12 @@ def build_context(start: Path | None = None) -> Context:
 
 
 def _load_config_or_default(repo_root: Path) -> dict[str, Any]:
-    try:
-        return load_config(repo_root)
-    except ConfigError:
+    # Only the missing-config case falls back to defaults — a present-but-malformed
+    # config.yaml (bad YAML, wrong shape) must propagate as an error, otherwise
+    # the workflow would silently use default author/paths/sandbox values while
+    # the user thinks their config is in effect.
+    config_path = repo_root / ".blogflow" / "config.yaml"
+    if not config_path.exists():
         return {
             "author": "author",
             "blog_dir": "docs/blog/posts",
@@ -101,6 +110,7 @@ def _load_config_or_default(repo_root: Path) -> dict[str, Any]:
             },
             "publish": {"update_updated_date": True, "ensure_draft_false": True},
         }
+    return load_config(repo_root)
 
 
 def _optional_timeout(value: Any) -> int | None:

--- a/tools/blogflow/blogflow/commands/answer.py
+++ b/tools/blogflow/blogflow/commands/answer.py
@@ -1,0 +1,88 @@
+"""`blogflow answer` — record author answers to the brief questions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+from .. import state
+from ..models import Brief
+from . import _context as ctx_mod
+
+
+@click.command("answer")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+@click.option(
+    "--file", "file_path", type=click.Path(path_type=Path, exists=True), default=None
+)
+@click.option("--interactive", is_flag=True, default=False)
+def answer_cmd(
+    session_id: str | None, file_path: Path | None, interactive: bool
+) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if session.status != state.STATUS_AWAITING_ANSWERS:
+        raise click.ClickException(
+            f"Session must be in {state.STATUS_AWAITING_ANSWERS!r}; got {session.status!r}. "
+            f"Next: {ctx_mod.next_hint(session.status)}"
+        )
+
+    brief_path = session_dir / "outputs" / "brief.json"
+    if not brief_path.exists():
+        raise click.ClickException(f"Brief output missing: {brief_path}")
+    brief = Brief.from_dict(ctx_mod.read_json(brief_path))
+
+    if not brief.questions:
+        answers: dict[str, str] = {}
+    elif file_path:
+        answers = _load_answers_file(file_path, brief)
+    elif interactive:
+        answers = _prompt_interactive(brief)
+    else:
+        raise click.ClickException("Provide --interactive or --file <answers.yaml>.")
+
+    ctx_mod.write_yaml(session_dir / "user" / "answers.yaml", {"answers": answers})
+
+    state.transition(session, state.STATUS_DRAFT_READY)
+    ctx.store.save(session)
+    click.echo(f"answers → {session_dir / 'user' / 'answers.yaml'}")
+    click.echo("Next: blogflow draft")
+
+
+def _load_answers_file(path: Path, brief: Brief) -> dict[str, str]:
+    data: Any = ctx_mod.read_yaml(path)
+    raw = data.get("answers") if isinstance(data.get("answers"), dict) else data
+    if not isinstance(raw, dict):
+        raise click.ClickException(
+            f"{path} must contain a mapping of question_id → answer text."
+        )
+    valid_ids = {q.id for q in brief.questions}
+    out: dict[str, str] = {}
+    for qid, val in raw.items():
+        if qid not in valid_ids:
+            click.echo(f"warning: unknown question id {qid!r} in {path}; skipping")
+            continue
+        out[str(qid)] = str(val)
+    missing = valid_ids - set(out)
+    if missing:
+        click.echo(f"warning: no answer recorded for: {sorted(missing)}")
+    return out
+
+
+def _prompt_interactive(brief: Brief) -> dict[str, str]:
+    answers: dict[str, str] = {}
+    for q in brief.questions:
+        click.echo("")
+        click.echo(f"[{q.id}] {q.text}")
+        if q.why:
+            click.echo(f"  (왜: {q.why})")
+        val = click.prompt("  답변 (공백 = skip)", default="", show_default=False)
+        if val.strip():
+            answers[q.id] = val.strip()
+    return answers

--- a/tools/blogflow/blogflow/commands/approve.py
+++ b/tools/blogflow/blogflow/commands/approve.py
@@ -1,0 +1,39 @@
+"""`blogflow approve` — mark the final output as approved for publish."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import click
+
+from .. import state
+from . import _context as ctx_mod
+
+
+@click.command("approve")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+def approve_cmd(session_id: str | None) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if session.status != state.STATUS_FINAL_READY:
+        raise click.ClickException(
+            f"Session must be in {state.STATUS_FINAL_READY!r}; got {session.status!r}. "
+            f"Next: {ctx_mod.next_hint(session.status)}"
+        )
+
+    final_path = session_dir / "outputs" / "final.md"
+    if not final_path.exists():
+        raise click.ClickException(
+            f"Final output missing: {final_path}. Run `blogflow finalize` first."
+        )
+
+    state.transition(session, state.STATUS_APPROVED)
+    session.approved_at = datetime.now().isoformat(timespec="seconds")
+    ctx.store.save(session)
+
+    click.echo(f"approved: {session.id} at {session.approved_at}")
+    click.echo("Next: blogflow publish")

--- a/tools/blogflow/blogflow/commands/brief.py
+++ b/tools/blogflow/blogflow/commands/brief.py
@@ -1,0 +1,76 @@
+"""`blogflow brief` — structured learning brief + author questions."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .. import prompts, state
+from ..errors import AdapterError
+from ..schemas import BRIEF_SCHEMA
+from . import _context as ctx_mod
+
+
+@click.command("brief")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+def brief_cmd(session_id: str | None) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if session.status != state.STATUS_INITIATED:
+        raise click.ClickException(
+            f"Session must be in {state.STATUS_INITIATED!r}; got {session.status!r}. "
+            f"Next: {ctx_mod.next_hint(session.status)}"
+        )
+
+    prompt = prompts.render(
+        "brief",
+        {
+            "author": ctx.author(),
+            "default_category": ctx.default_category(),
+            "session": session,
+            "recent_titles": ctx.recent_post_titles(),
+        },
+        ctx.repo_root,
+    )
+    ctx_mod.write_prompt(session_dir, "brief", prompt)
+
+    adapter = ctx.claude_adapter()
+    result = adapter.run(
+        prompt,
+        schema=BRIEF_SCHEMA,
+        log_dir=session_dir / "logs",
+        stage="brief",
+    )
+    if not result.ok:
+        raise AdapterError(
+            f"claude brief failed (exit={result.exit_code}). See log under {session_dir / 'logs'}."
+        )
+
+    parsed = result.parsed or _loose_parse(result.text)
+    if parsed is None:
+        raise AdapterError("Could not parse brief JSON. See log.")
+
+    ctx_mod.write_json(session_dir / "outputs" / "brief.json", parsed)
+    ctx_mod.write_json(session_dir / "schemas" / "brief.schema.json", BRIEF_SCHEMA)
+
+    state.transition(session, state.STATUS_BRIEF_READY)
+    state.transition(session, state.STATUS_AWAITING_ANSWERS)
+    ctx.store.save(session)
+
+    click.echo(f"brief → {session_dir / 'outputs' / 'brief.json'}")
+    qs = parsed.get("questions") or []
+    click.echo(f"{len(qs)} question(s) for the author.")
+    click.echo("Next: blogflow answer --interactive   (or --file answers.yaml)")
+
+
+def _loose_parse(text: str) -> dict | None:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None

--- a/tools/blogflow/blogflow/commands/draft.py
+++ b/tools/blogflow/blogflow/commands/draft.py
@@ -1,0 +1,100 @@
+"""`blogflow draft` — Claude generates the full draft body + metadata."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from .. import prompts, state
+from ..errors import AdapterError
+from ..models import Brief
+from ..schemas import DRAFT_SCHEMA
+from . import _context as ctx_mod
+
+
+@click.command("draft")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+def draft_cmd(session_id: str | None) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if session.status != state.STATUS_DRAFT_READY:
+        raise click.ClickException(
+            f"Session must be in {state.STATUS_DRAFT_READY!r}; got {session.status!r}. "
+            f"Next: {ctx_mod.next_hint(session.status)}"
+        )
+
+    brief = Brief.from_dict(ctx_mod.read_json(session_dir / "outputs" / "brief.json"))
+    answers = (
+        ctx_mod.read_yaml(session_dir / "user" / "answers.yaml").get("answers") or {}
+    )
+
+    # On a revise-loop rerun, feed only the prior review back. We deliberately
+    # do NOT include the previous draft: it roughly doubles input tokens for
+    # little gain, since review.md already names the sentences to rewrite.
+    prior_review = None
+    if session.review_gate in {"revise", "block"}:
+        review_path = session_dir / "outputs" / "review.md"
+        if review_path.exists():
+            prior_review = review_path.read_text(encoding="utf-8")
+
+    prompt = prompts.render(
+        "draft",
+        {
+            "author": ctx.author(),
+            "session": session,
+            "brief": brief,
+            "answers": answers,
+            "prior_review": prior_review,
+        },
+        ctx.repo_root,
+    )
+    ctx_mod.write_prompt(session_dir, "draft", prompt)
+
+    adapter = ctx.claude_adapter()
+    result = adapter.run(
+        prompt,
+        schema=DRAFT_SCHEMA,
+        log_dir=session_dir / "logs",
+        stage="draft",
+    )
+    if not result.ok:
+        raise AdapterError(
+            f"claude draft failed (exit={result.exit_code}). See log under {session_dir / 'logs'}."
+        )
+
+    parsed = result.parsed or _loose_parse(result.text)
+    if parsed is None:
+        raise AdapterError("Could not parse draft JSON. See log.")
+
+    ctx_mod.write_json(session_dir / "outputs" / "draft.json", parsed)
+    ctx_mod.write_json(session_dir / "schemas" / "draft.schema.json", DRAFT_SCHEMA)
+    (session_dir / "outputs" / "draft.md").write_text(
+        parsed.get("body_markdown", ""), encoding="utf-8"
+    )
+    ctx_mod.write_json(
+        session_dir / "outputs" / "draft.claims.json",
+        {
+            "claim_summary": parsed.get("claim_summary") or [],
+            "references": parsed.get("references") or [],
+            "known_risks": parsed.get("known_risks") or [],
+        },
+    )
+
+    state.transition(session, state.STATUS_UNDER_REVIEW)
+    ctx.store.save(session)
+
+    click.echo(f"draft → {session_dir / 'outputs' / 'draft.md'}")
+    click.echo("Next: blogflow review")
+
+
+def _loose_parse(text: str) -> dict | None:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None

--- a/tools/blogflow/blogflow/commands/finalize.py
+++ b/tools/blogflow/blogflow/commands/finalize.py
@@ -1,0 +1,166 @@
+"""`blogflow finalize` — merge draft/review/reflection into a final body."""
+
+from __future__ import annotations
+
+import re
+
+import click
+
+from .. import prompts, state
+from ..errors import AdapterError
+from ..models import Brief, Draft, Review
+from . import _context as ctx_mod
+
+# Match `[SUPPORTED:<label>]` (any non-`]` content inside) and bare `[ASSUMED]`.
+# The optional leading whitespace eats the space between prose and the marker
+# so `"header is 20 bytes [SUPPORTED:RFC 791]."` → `"header is 20 bytes."`.
+_PROVENANCE_MARKER_RE = re.compile(
+    r"[ \t]*\[(?:SUPPORTED:[^\]]+|ASSUMED)\]",
+    re.IGNORECASE,
+)
+
+
+def strip_provenance_markers(text: str) -> str:
+    """Remove `[SUPPORTED:<label>]` and `[ASSUMED]` tags from rendered prose.
+
+    Draft/review stages rely on these markers for provenance auditing, but
+    they must never reach the public post body — they look like unfinished
+    annotations to readers.
+    """
+    return _PROVENANCE_MARKER_RE.sub("", text)
+
+
+@click.command("finalize")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+@click.option(
+    "--deterministic",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip the Claude polish pass and concatenate draft + reflection as-is. "
+        "Use this only when the review has no Required-fixes to apply; otherwise "
+        "review feedback is silently dropped."
+    ),
+)
+def finalize_cmd(session_id: str | None, deterministic: bool) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if session.status != state.STATUS_FINAL_READY:
+        raise click.ClickException(
+            f"Session must be in {state.STATUS_FINAL_READY!r}; got {session.status!r}. "
+            f"Next: {ctx_mod.next_hint(session.status)}"
+        )
+
+    brief = Brief.from_dict(ctx_mod.read_json(session_dir / "outputs" / "brief.json"))
+    draft_data = ctx_mod.read_json(session_dir / "outputs" / "draft.json")
+    draft = Draft(
+        title_candidates=list(draft_data.get("title_candidates") or []),
+        description_candidates=list(draft_data.get("description_candidates") or []),
+        body_markdown=draft_data.get("body_markdown", ""),
+        claim_summary=list(draft_data.get("claim_summary") or []),
+        references=list(draft_data.get("references") or []),
+        known_risks=list(draft_data.get("known_risks") or []),
+    )
+    review_path = session_dir / "outputs" / "review.md"
+    review_raw = review_path.read_text(encoding="utf-8") if review_path.exists() else ""
+    review = Review(raw=review_raw, gate=(session.review_gate or "approved"))
+    reflection_path = session_dir / "user" / "reflection.md"
+    reflection_text = (
+        reflection_path.read_text(encoding="utf-8").strip()
+        if reflection_path.exists() and not session.reflection_skipped
+        else ""
+    )
+
+    has_review_body = bool(review_raw.strip())
+
+    if deterministic:
+        # Explicit opt-out: warn if we're about to ignore non-trivial review content.
+        if has_review_body and not _review_is_trivially_approved(review_raw):
+            click.echo(
+                "warning: --deterministic skips Claude polish. The review may "
+                "have Required-fixes that will NOT be applied to final.md."
+            )
+            click.echo("         Run without --deterministic to merge them.")
+        final_body = _deterministic_merge(draft, reflection_text)
+    else:
+        # Default path: polish via Claude so review Required-fixes are applied
+        # and internal provenance markers are stripped from the prose.
+        final_body = _regenerate_via_claude(
+            ctx, session, session_dir, brief, draft, review, reflection_text
+        )
+
+    # Safety net: strip any provenance markers that survived the finalize
+    # stage (happens when --deterministic is used, and defends against the
+    # regenerate prompt being ignored by Claude).
+    final_body = strip_provenance_markers(final_body)
+
+    (session_dir / "outputs" / "final.md").write_text(final_body, encoding="utf-8")
+
+    state.transition(session, state.STATUS_FINAL_READY)  # idempotent no-op
+    ctx.store.save(session)
+    click.echo(f"final → {session_dir / 'outputs' / 'final.md'}")
+    click.echo("Next: blogflow approve")
+
+
+def _deterministic_merge(draft: Draft, reflection_text: str) -> str:
+    body = draft.body_markdown.rstrip() + "\n"
+    if reflection_text:
+        body += "\n## 회고\n\n" + reflection_text.strip() + "\n"
+    return body
+
+
+def _review_is_trivially_approved(review_raw: str) -> bool:
+    """Best-effort check: review body declares `Required fixes: None`.
+
+    Used only to decide whether --deterministic deserves a warning. False
+    positives just produce a spurious warning; false negatives mean the user
+    misses one. Neither changes behavior — it's a UX hint.
+    """
+    # Look for the "Required fixes" heading followed by a "None" line within a
+    # handful of lines. The reviewer template emits "> None — draft is …" but
+    # freeform reviews may phrase it differently.
+    m = re.search(r"required\s+fixes[^\n]*\n+([\s\S]{0,200})", review_raw, re.IGNORECASE)
+    if not m:
+        return False
+    snippet = m.group(1).lower()
+    return bool(re.search(r"\bnone\b", snippet))
+
+
+def _regenerate_via_claude(
+    ctx,
+    session,
+    session_dir,
+    brief,
+    draft,
+    review,
+    reflection_text,
+) -> str:
+    prompt = prompts.render(
+        "finalize",
+        {
+            "author": ctx.author(),
+            "session": session,
+            "brief": brief,
+            "draft": draft,
+            "review": review,
+            "reflection": reflection_text,
+        },
+        ctx.repo_root,
+    )
+    ctx_mod.write_prompt(session_dir, "finalize", prompt)
+    adapter = ctx.claude_adapter()
+    result = adapter.run(
+        prompt,
+        schema=None,
+        log_dir=session_dir / "logs",
+        stage="finalize",
+    )
+    if not result.ok or not result.text.strip():
+        raise AdapterError(
+            f"claude finalize failed (exit={result.exit_code}). See log under {session_dir / 'logs'}."
+        )
+    return result.text.strip() + "\n"

--- a/tools/blogflow/blogflow/commands/finalize.py
+++ b/tools/blogflow/blogflow/commands/finalize.py
@@ -123,7 +123,9 @@ def _review_is_trivially_approved(review_raw: str) -> bool:
     # Look for the "Required fixes" heading followed by a "None" line within a
     # handful of lines. The reviewer template emits "> None — draft is …" but
     # freeform reviews may phrase it differently.
-    m = re.search(r"required\s+fixes[^\n]*\n+([\s\S]{0,200})", review_raw, re.IGNORECASE)
+    m = re.search(
+        r"required\s+fixes[^\n]*\n+([\s\S]{0,200})", review_raw, re.IGNORECASE
+    )
     if not m:
         return False
     snippet = m.group(1).lower()

--- a/tools/blogflow/blogflow/commands/ideas.py
+++ b/tools/blogflow/blogflow/commands/ideas.py
@@ -1,0 +1,75 @@
+"""`blogflow ideas` — generate topic candidates."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import click
+
+from .. import prompts
+from ..errors import AdapterError
+from ..schemas import IDEAS_SCHEMA
+from . import _context as ctx_mod
+
+
+@click.command("ideas")
+@click.option("--category", default=None, help="Focus category for the brainstorm.")
+@click.option("--count", default=5, type=int, help="How many ideas to request.")
+def ideas_cmd(category: str | None, count: int) -> None:
+    """Ask Claude for fresh blog post ideas and save them under `.blogflow/ideas/`."""
+    ctx = ctx_mod.build_context()
+    prompt_context = {
+        "author": ctx.author(),
+        "default_category": ctx.default_category(),
+        "category": category,
+        "count": count,
+        "recent_titles": ctx.recent_post_titles(),
+    }
+    prompt = prompts.render("ideas", prompt_context, ctx.repo_root)
+
+    ideas_dir = ctx.repo_root / ".blogflow" / "ideas"
+    ideas_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_dir = ideas_dir / "logs"
+
+    adapter = ctx.claude_adapter()
+    result = adapter.run(
+        prompt,
+        schema=IDEAS_SCHEMA,
+        log_dir=log_dir,
+        stage="ideas",
+    )
+    if not result.ok:
+        raise AdapterError(
+            f"claude ideas failed (exit={result.exit_code}). See log at {log_dir}."
+        )
+
+    payload = result.parsed or _try_parse(result.text)
+    if payload is None:
+        raise AdapterError(
+            "Could not parse ideas response as JSON. Raw text saved in log."
+        )
+
+    out_path = ideas_dir / f"{ts}.yaml"
+    _write_ideas(out_path, payload)
+    click.echo(f"Saved {len(payload.get('ideas', []))} ideas → {out_path}")
+    click.echo('Next: pick one and run `blogflow init --topic "..."`.')
+
+
+def _try_parse(text: str) -> dict | None:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _write_ideas(path: Path, payload: dict) -> None:
+    import yaml
+
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )

--- a/tools/blogflow/blogflow/commands/init.py
+++ b/tools/blogflow/blogflow/commands/init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import click
 
-from ..publish import validate_post_path
+from ..publish import DEFAULT_BLOG_DIR, validate_post_path
 from ..state import Session, new_session_id, slugify
 from . import _context as ctx_mod
 
@@ -28,7 +28,8 @@ def init_cmd(topic: str, post_path: str | None, from_idea: str | None) -> None:
     ctx = ctx_mod.build_context()
 
     if post_path:
-        validate_post_path(ctx.repo_root, post_path)
+        blog_dir = str(ctx.config.get("blog_dir") or DEFAULT_BLOG_DIR)
+        validate_post_path(ctx.repo_root, post_path, blog_dir)
 
     sid = new_session_id(topic, existing=set(ctx.store.list_sessions()))
     session = Session(

--- a/tools/blogflow/blogflow/commands/init.py
+++ b/tools/blogflow/blogflow/commands/init.py
@@ -1,0 +1,51 @@
+"""`blogflow init` — create a new session."""
+
+from __future__ import annotations
+
+import click
+
+from ..publish import validate_post_path
+from ..state import Session, new_session_id, slugify
+from . import _context as ctx_mod
+
+
+@click.command("init")
+@click.option("--topic", required=True, help="Topic title for the post.")
+@click.option(
+    "--post-path",
+    "post_path",
+    default=None,
+    help="Target post file relative to repo root (must live under docs/blog/posts/).",
+)
+@click.option(
+    "--from-idea",
+    "from_idea",
+    default=None,
+    help="Optional reference back to an ideas/<ts>.yaml entry id — stored as-is in session metadata.",
+)
+def init_cmd(topic: str, post_path: str | None, from_idea: str | None) -> None:
+    """Create a new session directory and YAML under `.blogflow/sessions/`."""
+    ctx = ctx_mod.build_context()
+
+    if post_path:
+        validate_post_path(ctx.repo_root, post_path)
+
+    sid = new_session_id(topic, existing=set(ctx.store.list_sessions()))
+    session = Session(
+        id=sid,
+        topic=topic,
+        slug=slugify(topic),
+        target_post_path=post_path,
+    )
+    ctx.store.create(session)
+
+    if from_idea:
+        meta_path = ctx.store.session_path(sid) / "user" / "origin.yaml"
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(f"from_idea: {from_idea}\n", encoding="utf-8")
+
+    click.echo(f"Session created: {sid}")
+    click.echo(f"  topic: {topic}")
+    if post_path:
+        click.echo(f"  target_post_path: {post_path}")
+    click.echo("Next: blogflow brief")

--- a/tools/blogflow/blogflow/commands/publish.py
+++ b/tools/blogflow/blogflow/commands/publish.py
@@ -35,10 +35,7 @@ def publish_cmd(session_id: str | None, post_path_override: str | None) -> None:
     if post_path_override is not None:
         # Validate first so a bad path doesn't mutate the session silently.
         publish_mod.validate_post_path(ctx.repo_root, post_path_override)
-        if (
-            session.target_post_path
-            and session.target_post_path != post_path_override
-        ):
+        if session.target_post_path and session.target_post_path != post_path_override:
             click.echo(
                 f"overriding target_post_path: "
                 f"{session.target_post_path} → {post_path_override}"

--- a/tools/blogflow/blogflow/commands/publish.py
+++ b/tools/blogflow/blogflow/commands/publish.py
@@ -31,10 +31,11 @@ def publish_cmd(session_id: str | None, post_path_override: str | None) -> None:
     ctx = ctx_mod.build_context()
     session = ctx.store.resolve_latest(session_id)
     session_dir = ctx.store.session_path(session.id)
+    blog_dir = str(ctx.config.get("blog_dir") or publish_mod.DEFAULT_BLOG_DIR)
 
     if post_path_override is not None:
         # Validate first so a bad path doesn't mutate the session silently.
-        publish_mod.validate_post_path(ctx.repo_root, post_path_override)
+        publish_mod.validate_post_path(ctx.repo_root, post_path_override, blog_dir)
         if session.target_post_path and session.target_post_path != post_path_override:
             click.echo(
                 f"overriding target_post_path: "
@@ -51,9 +52,12 @@ def publish_cmd(session_id: str | None, post_path_override: str | None) -> None:
         final_path=final_path,
     )
 
-    post_path = publish_mod.validate_post_path(ctx.repo_root, session.target_post_path)
+    post_path = publish_mod.validate_post_path(
+        ctx.repo_root, session.target_post_path, blog_dir
+    )
     publish_cfg = ctx.config.get("publish") or {}
     ensure_draft_false = bool(publish_cfg.get("ensure_draft_false", True))
+    update_updated_date = bool(publish_cfg.get("update_updated_date", True))
 
     # Warn if we're about to replace a non-trivial existing body. The author
     # can Ctrl+C, restore from git, and merge manually instead of losing content.
@@ -79,6 +83,7 @@ def publish_cmd(session_id: str | None, post_path_override: str | None) -> None:
         ensure_draft_false=ensure_draft_false,
         topic=session.topic,
         author=ctx.author(),
+        update_updated_date=update_updated_date,
     )
 
     state.transition(session, state.STATUS_PUBLISHED)
@@ -90,5 +95,7 @@ def publish_cmd(session_id: str | None, post_path_override: str | None) -> None:
     click.echo(f"published → {rel_post}")
     click.echo("")
     click.echo("suggested git commands (run yourself when ready):")
-    for cmd in publish_mod.suggested_git_commands(rel_post, session_rel):
+    for cmd in publish_mod.suggested_git_commands(
+        rel_post, session_rel, repo_root=ctx.repo_root
+    ):
         click.echo(f"  {cmd}")

--- a/tools/blogflow/blogflow/commands/publish.py
+++ b/tools/blogflow/blogflow/commands/publish.py
@@ -1,0 +1,97 @@
+"""`blogflow publish` — write the final body into the target post file."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+import click
+
+from .. import frontmatter as fm_mod
+from .. import publish as publish_mod
+from .. import state
+from . import _context as ctx_mod
+
+
+@click.command("publish")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+@click.option(
+    "--post-path",
+    "post_path_override",
+    default=None,
+    help=(
+        "Set or override the target post path for this session. Useful when "
+        "`blogflow init` was run without `--post-path`. Path must live under "
+        "docs/blog/posts/ and end in .md."
+    ),
+)
+def publish_cmd(session_id: str | None, post_path_override: str | None) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if post_path_override is not None:
+        # Validate first so a bad path doesn't mutate the session silently.
+        publish_mod.validate_post_path(ctx.repo_root, post_path_override)
+        if (
+            session.target_post_path
+            and session.target_post_path != post_path_override
+        ):
+            click.echo(
+                f"overriding target_post_path: "
+                f"{session.target_post_path} → {post_path_override}"
+            )
+        session.target_post_path = post_path_override
+        ctx.store.save(session)
+
+    final_path = session_dir / "outputs" / "final.md"
+    publish_mod.guard_publish(
+        status=session.status,
+        expected_status=state.STATUS_APPROVED,
+        target_post_path=session.target_post_path,
+        final_path=final_path,
+    )
+
+    post_path = publish_mod.validate_post_path(ctx.repo_root, session.target_post_path)
+    publish_cfg = ctx.config.get("publish") or {}
+    ensure_draft_false = bool(publish_cfg.get("ensure_draft_false", True))
+
+    # Warn if we're about to replace a non-trivial existing body. The author
+    # can Ctrl+C, restore from git, and merge manually instead of losing content.
+    if post_path.exists():
+        try:
+            existing = fm_mod.read(post_path)
+            if len((existing.body or "").strip()) > 40:
+                click.echo(
+                    f"warning: {session.target_post_path} has an existing body "
+                    f"(~{len(existing.body)} chars) that will be replaced."
+                )
+                click.echo(
+                    "         Review with `git diff` after publish; restore "
+                    "hand-written sections if needed."
+                )
+        except Exception:
+            pass
+
+    publish_mod.merge_final_into_post(
+        post_path,
+        final_path.read_text(encoding="utf-8"),
+        today=date.today(),
+        ensure_draft_false=ensure_draft_false,
+        topic=session.topic,
+        author=ctx.author(),
+    )
+
+    state.transition(session, state.STATUS_PUBLISHED)
+    session.published_at = datetime.now().isoformat(timespec="seconds")
+    ctx.store.save(session)
+
+    session_rel = ctx_mod.session_rel_path(ctx, session)
+    rel_post = Path(session.target_post_path)
+    click.echo(f"published → {rel_post}")
+    click.echo("")
+    click.echo("suggested git commands (run yourself when ready):")
+    for cmd in publish_mod.suggested_git_commands(rel_post, session_rel):
+        click.echo(f"  {cmd}")

--- a/tools/blogflow/blogflow/commands/reflection.py
+++ b/tools/blogflow/blogflow/commands/reflection.py
@@ -1,0 +1,112 @@
+"""`blogflow reflection` — record the author's optional closing reflection."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+import click
+
+from .. import prompts, state
+from . import _context as ctx_mod
+
+
+@click.command("reflection")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+@click.option("--skip", is_flag=True, default=False, help="Skip the reflection stage.")
+@click.option("--text", default=None, help="Inline reflection text.")
+@click.option(
+    "--file",
+    "file_path",
+    type=click.Path(path_type=Path, exists=True),
+    default=None,
+    help="Path to a markdown file to use as the reflection.",
+)
+def reflection_cmd(
+    session_id: str | None,
+    skip: bool,
+    text: str | None,
+    file_path: Path | None,
+) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if session.status != state.STATUS_AWAITING_REFLECTION:
+        raise click.ClickException(
+            f"Session must be in {state.STATUS_AWAITING_REFLECTION!r}; got {session.status!r}. "
+            f"Next: {ctx_mod.next_hint(session.status)}"
+        )
+
+    content = _resolve_content(
+        ctx_ref=ctx, session=session, skip=skip, text=text, file_path=file_path
+    )
+
+    reflection_path = session_dir / "user" / "reflection.md"
+    if content:
+        reflection_path.parent.mkdir(parents=True, exist_ok=True)
+        reflection_path.write_text(content, encoding="utf-8")
+        session.reflection_skipped = False
+        click.echo(f"reflection → {reflection_path}")
+    else:
+        session.reflection_skipped = True
+        click.echo("reflection skipped.")
+
+    state.transition(session, state.STATUS_FINAL_READY)
+    ctx.store.save(session)
+    click.echo("Next: blogflow finalize")
+
+
+def _resolve_content(
+    *,
+    ctx_ref,
+    session,
+    skip: bool,
+    text: str | None,
+    file_path: Path | None,
+) -> str:
+    if skip:
+        return ""
+    if text is not None:
+        return text.strip()
+    if file_path is not None:
+        return file_path.read_text(encoding="utf-8").strip()
+    return _editor_flow(ctx_ref, session)
+
+
+def _editor_flow(ctx_ref, session) -> str:
+    primer = prompts.render(
+        "reflection",
+        {"author": ctx_ref.author(), "session": session},
+        ctx_ref.repo_root,
+    )
+    header = (
+        "# Write your reflection below (save + close to submit, leave empty to skip).\n"
+        "# Lines starting with # are ignored.\n"
+    )
+    primer_comment = "\n".join(
+        f"# {line}" if line else "#" for line in primer.splitlines()
+    )
+    template = header + primer_comment + "\n\n"
+
+    editor_env = os.environ.get("EDITOR") or "vi"
+    editor_cmd = shlex.split(editor_env) or ["vi"]
+    fd, tmp = tempfile.mkstemp(prefix="blogflow-reflection-", suffix=".md")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(template)
+        subprocess.run([*editor_cmd, tmp], check=False)
+        raw = Path(tmp).read_text(encoding="utf-8")
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+
+    lines = [ln for ln in raw.splitlines() if not ln.lstrip().startswith("#")]
+    return "\n".join(lines).strip()

--- a/tools/blogflow/blogflow/commands/review.py
+++ b/tools/blogflow/blogflow/commands/review.py
@@ -1,0 +1,167 @@
+"""`blogflow review` — Codex reviews the draft and emits a GATE decision."""
+
+from __future__ import annotations
+
+import click
+
+from .. import prompts, state
+from ..adapters.codex import (
+    GATE_APPROVED,
+    GATE_BLOCK,
+    GATE_REVISE,
+    GATE_UNCLEAR,
+    parse_gate,
+)
+from ..errors import AdapterError
+from ..models import Brief, Draft
+from . import _context as ctx_mod
+
+
+_GATE_TO_STATE = {
+    GATE_APPROVED: state.STATUS_AWAITING_REFLECTION,
+    GATE_REVISE: state.STATUS_DRAFT_READY,
+    GATE_BLOCK: state.STATUS_DRAFT_READY,
+}
+
+# After this many automatic revise-loops, the review command stops transitioning
+# on REVISE/BLOCK and forces the author to decide manually. Without this cap,
+# the reviewer and author can spin indefinitely on non-blocking nits.
+MAX_AUTO_REVISE = 1
+
+
+@click.command("review")
+@click.option(
+    "--session", "session_id", default=None, help="Session id (defaults to latest)."
+)
+@click.option(
+    "--gate",
+    "manual_gate",
+    type=click.Choice(["approved", "revise", "block"], case_sensitive=False),
+    default=None,
+    help=(
+        "Skip the Codex invocation and apply a manual gate decision. "
+        "Use this to resolve an UNCLEAR review or to override what Codex produced."
+    ),
+)
+def review_cmd(session_id: str | None, manual_gate: str | None) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    if session.status != state.STATUS_UNDER_REVIEW:
+        raise click.ClickException(
+            f"Session must be in {state.STATUS_UNDER_REVIEW!r}; got {session.status!r}. "
+            f"Next: {ctx_mod.next_hint(session.status)}"
+        )
+
+    if manual_gate is not None:
+        _apply_manual_gate(ctx, session, session_dir, manual_gate.upper())
+        return
+
+    brief = Brief.from_dict(ctx_mod.read_json(session_dir / "outputs" / "brief.json"))
+    draft_data = ctx_mod.read_json(session_dir / "outputs" / "draft.json")
+    draft = Draft(
+        title_candidates=list(draft_data.get("title_candidates") or []),
+        description_candidates=list(draft_data.get("description_candidates") or []),
+        body_markdown=draft_data.get("body_markdown", ""),
+        claim_summary=list(draft_data.get("claim_summary") or []),
+        references=list(draft_data.get("references") or []),
+        known_risks=list(draft_data.get("known_risks") or []),
+    )
+
+    prompt = prompts.render(
+        "review",
+        {"author": ctx.author(), "session": session, "brief": brief, "draft": draft},
+        ctx.repo_root,
+    )
+    ctx_mod.write_prompt(session_dir, "review", prompt)
+
+    adapter = ctx.codex_adapter()
+    result = adapter.run(
+        prompt,
+        log_dir=session_dir / "logs",
+        stage="review",
+        extra={"mode": "review"},
+    )
+    if not result.ok:
+        raise AdapterError(
+            f"codex review failed (exit={result.exit_code}). See log under {session_dir / 'logs'}."
+        )
+
+    (session_dir / "outputs" / "review.md").write_text(result.text, encoding="utf-8")
+    gate = parse_gate(result.text)
+    _persist_gate_and_transition(ctx, session, session_dir, gate)
+
+
+def _apply_manual_gate(ctx, session, session_dir, gate_upper: str) -> None:
+    """Skip Codex; record the gate and transition the session."""
+    review_path = session_dir / "outputs" / "review.md"
+    if not review_path.exists():
+        review_path.parent.mkdir(parents=True, exist_ok=True)
+        review_path.write_text(
+            f"(no codex review captured — gate manually set to {gate_upper.lower()})\n",
+            encoding="utf-8",
+        )
+    _persist_gate_and_transition(ctx, session, session_dir, gate_upper, manual=True)
+
+
+def _persist_gate_and_transition(
+    ctx,
+    session,
+    session_dir,
+    gate_upper: str,
+    *,
+    manual: bool = False,
+) -> None:
+    meta: dict = {"gate": gate_upper.lower()}
+    if manual:
+        meta["manual"] = True
+    ctx_mod.write_yaml(session_dir / "outputs" / "review.meta.yaml", meta)
+    session.review_gate = gate_upper.lower()
+
+    label = "manual" if manual else "codex"
+    review_out = session_dir / "outputs" / "review.md"
+
+    # Auto loop cap: once we've already done MAX_AUTO_REVISE automatic revise
+    # cycles, do not auto-transition on REVISE/BLOCK. Make the author look at
+    # the review and decide — most late-cycle flags are non-blocking nits.
+    if (
+        not manual
+        and gate_upper in {GATE_REVISE, GATE_BLOCK}
+        and session.revise_count >= MAX_AUTO_REVISE
+    ):
+        ctx.store.save(session)
+        click.echo(f"review → {review_out}")
+        click.echo(
+            f"gate ({label}): {gate_upper} — but this session already ran "
+            f"{session.revise_count} revise cycle(s)."
+        )
+        click.echo(
+            "Auto-loop stopped to avoid burning tokens on non-blocking nits. "
+            "Read the review and pick:"
+        )
+        click.echo("  blogflow review --gate approved   # ship it")
+        click.echo("  blogflow review --gate revise     # one more draft pass")
+        click.echo("  blogflow review --gate block      # one more draft pass")
+        return
+
+    if gate_upper in _GATE_TO_STATE:
+        # Increment only on an auto (codex-emitted) REVISE/BLOCK — manual gate
+        # overrides don't count against the loop cap.
+        if not manual and gate_upper in {GATE_REVISE, GATE_BLOCK}:
+            session.revise_count += 1
+        state.transition(session, _GATE_TO_STATE[gate_upper])
+        ctx.store.save(session)
+        click.echo(f"review → {review_out}")
+        click.echo(f"gate ({label}): {gate_upper}")
+        click.echo(f"Next: {ctx_mod.next_hint(session.status)}")
+        return
+
+    # Unclear — persist and prompt author for manual resolution.
+    ctx.store.save(session)
+    click.echo(f"review → {review_out}")
+    click.echo(f"gate ({label}): {GATE_UNCLEAR} — Codex did not emit a `GATE:` line.")
+    click.echo("Resolve by re-running with a manual decision:")
+    click.echo("  blogflow review --gate approved   # send to reflection")
+    click.echo("  blogflow review --gate revise     # loop back to draft")
+    click.echo("  blogflow review --gate block      # loop back to draft")

--- a/tools/blogflow/blogflow/commands/status.py
+++ b/tools/blogflow/blogflow/commands/status.py
@@ -1,0 +1,42 @@
+"""`blogflow status` — show the latest session's state and next step."""
+
+from __future__ import annotations
+
+import click
+
+from . import _context as ctx_mod
+
+
+@click.command("status")
+@click.option(
+    "--session",
+    "session_id",
+    default=None,
+    help="Specific session id (defaults to latest).",
+)
+def status_cmd(session_id: str | None) -> None:
+    ctx = ctx_mod.build_context()
+    session = ctx.store.resolve_latest(session_id)
+    session_dir = ctx.store.session_path(session.id)
+
+    click.echo(f"session:  {session.id}")
+    click.echo(f"topic:    {session.topic}")
+    click.echo(f"status:   {session.status}")
+    click.echo(f"created:  {session.created_at}")
+    click.echo(f"updated:  {session.updated_at}")
+    if session.target_post_path:
+        click.echo(f"target:   {session.target_post_path}")
+    if session.review_gate:
+        click.echo(f"gate:     {session.review_gate}")
+
+    click.echo("")
+    click.echo("artifacts:")
+    for sub in ("prompts", "outputs", "user", "logs"):
+        d = session_dir / sub
+        if not d.exists():
+            continue
+        for p in sorted(d.iterdir()):
+            click.echo(f"  {p.relative_to(session_dir)}")
+
+    click.echo("")
+    click.echo(f"next: {ctx_mod.next_hint(session.status)}")

--- a/tools/blogflow/blogflow/errors.py
+++ b/tools/blogflow/blogflow/errors.py
@@ -1,0 +1,31 @@
+"""Typed errors used across blogflow commands."""
+
+from __future__ import annotations
+
+
+class BlogflowError(Exception):
+    """Base class."""
+
+
+class StateError(BlogflowError):
+    """Illegal workflow transition."""
+
+    def __init__(self, message: str, expected_command: str | None = None):
+        super().__init__(message)
+        self.expected_command = expected_command
+
+
+class AdapterError(BlogflowError):
+    """LLM adapter invocation failure."""
+
+
+class PublishError(BlogflowError):
+    """Safety guard tripped during publish."""
+
+
+class SessionNotFoundError(BlogflowError):
+    """No session resolvable from CLI arguments."""
+
+
+class ConfigError(BlogflowError):
+    """Config file missing or malformed."""

--- a/tools/blogflow/blogflow/frontmatter.py
+++ b/tools/blogflow/blogflow/frontmatter.py
@@ -1,0 +1,63 @@
+"""Safe YAML frontmatter read / update for MkDocs post files."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from .errors import PublishError
+from .models import Frontmatter
+
+FENCE = "---"
+
+
+def parse(text: str) -> Frontmatter:
+    if not text.startswith(FENCE):
+        return Frontmatter(raw={}, body=text)
+    parts = text.split(FENCE, 2)
+    if len(parts) < 3:
+        raise PublishError("Frontmatter fence opened but not closed.")
+    try:
+        meta = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError as exc:
+        raise PublishError(f"Invalid YAML frontmatter: {exc}") from exc
+    if not isinstance(meta, dict):
+        raise PublishError("Frontmatter must be a YAML mapping.")
+    body = parts[2].lstrip("\n")
+    return Frontmatter(raw=meta, body=body)
+
+
+def read(path: Path) -> Frontmatter:
+    return parse(path.read_text(encoding="utf-8"))
+
+
+def dump(fm: Frontmatter) -> str:
+    yaml_text = yaml.safe_dump(
+        fm.raw,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).rstrip("\n")
+    body = fm.body
+    if body and not body.endswith("\n"):
+        body += "\n"
+    return f"{FENCE}\n{yaml_text}\n{FENCE}\n\n{body}"
+
+
+def write_atomic(path: Path, fm: Frontmatter) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = dump(fm)
+    fd, tmp_path = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise

--- a/tools/blogflow/blogflow/models.py
+++ b/tools/blogflow/blogflow/models.py
@@ -67,14 +67,28 @@ class Frontmatter:
     raw: dict[str, Any]
     body: str
 
-    def ensure_published(self, *, today: date, ensure_draft_false: bool) -> None:
+    def ensure_published(
+        self,
+        *,
+        today: date,
+        ensure_draft_false: bool,
+        update_updated_date: bool = True,
+    ) -> None:
         if "date" not in self.raw or not isinstance(self.raw["date"], dict):
+            # Brand-new frontmatter: set both created and updated regardless
+            # of update_updated_date, since the file didn't have an `updated`
+            # field to preserve.
             self.raw["date"] = {
                 "created": today.isoformat(),
                 "updated": today.isoformat(),
             }
         else:
             self.raw["date"].setdefault("created", today.isoformat())
-            self.raw["date"]["updated"] = today.isoformat()
+            if update_updated_date:
+                self.raw["date"]["updated"] = today.isoformat()
+            else:
+                # Preserve whatever `updated` the author set manually, but
+                # still seed one if it's missing so the post is valid.
+                self.raw["date"].setdefault("updated", today.isoformat())
         if ensure_draft_false and self.raw.get("draft") is True:
             self.raw["draft"] = False

--- a/tools/blogflow/blogflow/models.py
+++ b/tools/blogflow/blogflow/models.py
@@ -1,0 +1,80 @@
+"""Typed dataclasses for session artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+
+@dataclass
+class BriefQuestion:
+    id: str
+    text: str
+    why: str = ""
+
+
+@dataclass
+class Brief:
+    goal: str
+    learning_brief: str
+    source_pack: list[dict[str, str]] = field(default_factory=list)
+    scope: str = ""
+    questions: list[BriefQuestion] = field(default_factory=list)
+    outline: list[str] = field(default_factory=list)
+    claim_categories: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Brief":
+        qs = [
+            BriefQuestion(
+                id=str(q.get("id", f"q{i + 1}")),
+                text=q.get("text", ""),
+                why=q.get("why", ""),
+            )
+            for i, q in enumerate(data.get("questions") or [])
+        ]
+        return cls(
+            goal=data.get("goal", ""),
+            learning_brief=data.get("learning_brief", ""),
+            source_pack=list(data.get("source_pack") or []),
+            scope=data.get("scope", ""),
+            questions=qs,
+            outline=list(data.get("outline") or []),
+            claim_categories=list(data.get("claim_categories") or []),
+        )
+
+
+@dataclass
+class Draft:
+    title_candidates: list[str]
+    description_candidates: list[str]
+    body_markdown: str
+    claim_summary: list[dict[str, str]] = field(default_factory=list)
+    references: list[dict[str, str]] = field(default_factory=list)
+    known_risks: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Review:
+    raw: str
+    gate: str  # "approved" | "revise" | "block" | "unclear"
+    findings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Frontmatter:
+    raw: dict[str, Any]
+    body: str
+
+    def ensure_published(self, *, today: date, ensure_draft_false: bool) -> None:
+        if "date" not in self.raw or not isinstance(self.raw["date"], dict):
+            self.raw["date"] = {
+                "created": today.isoformat(),
+                "updated": today.isoformat(),
+            }
+        else:
+            self.raw["date"].setdefault("created", today.isoformat())
+            self.raw["date"]["updated"] = today.isoformat()
+        if ensure_draft_false and self.raw.get("draft") is True:
+            self.raw["draft"] = False

--- a/tools/blogflow/blogflow/prompts.py
+++ b/tools/blogflow/blogflow/prompts.py
@@ -1,0 +1,46 @@
+"""Jinja2 prompt template loader (user override → package default)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import (
+    ChoiceLoader,
+    Environment,
+    FileSystemLoader,
+    PackageLoader,
+    StrictUndefined,
+)
+
+STAGE_TEMPLATES = {
+    "ideas": "ideas.md.j2",
+    "brief": "brief.md.j2",
+    "draft": "draft.md.j2",
+    "review": "review.md.j2",
+    "finalize": "finalize.md.j2",
+    "reflection": "reflection.md.j2",
+}
+
+
+def _environment(repo_root: Path) -> Environment:
+    user_dir = repo_root / ".blogflow" / "prompts"
+    loaders = []
+    if user_dir.exists():
+        loaders.append(FileSystemLoader(str(user_dir)))
+    loaders.append(PackageLoader("blogflow", "prompts_tpl"))
+    env = Environment(
+        loader=ChoiceLoader(loaders),
+        autoescape=False,
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+    return env
+
+
+def render(stage: str, context: dict[str, Any], repo_root: Path) -> str:
+    if stage not in STAGE_TEMPLATES:
+        raise KeyError(f"Unknown prompt stage: {stage}")
+    env = _environment(repo_root)
+    template = env.get_template(STAGE_TEMPLATES[stage])
+    return template.render(**context)

--- a/tools/blogflow/blogflow/prompts_tpl/brief.md.j2
+++ b/tools/blogflow/blogflow/prompts_tpl/brief.md.j2
@@ -1,0 +1,30 @@
+You are helping {{ author }} plan a technical blog post in Korean. Return a JSON object that matches the schema supplied via `--json-schema` — no prose, no markdown fences.
+
+## Topic
+{{ session.topic }}
+
+{% if session.target_post_path -%}
+Target file: `{{ session.target_post_path }}`
+{% endif %}
+
+## Author context
+- Blog language: Korean (technical, professional tone)
+- Default category: {{ default_category }}
+- Recent post titles:
+{%- for t in recent_titles %}
+  - {{ t }}
+{%- endfor %}
+
+## What to produce
+1. `goal` — one sentence on what a reader should be able to DO after reading.
+2. `learning_brief` — 3-6 sentence plain-language primer of the key concepts.
+3. `source_pack` — authoritative references (RFC, official docs, primary papers). Omit any source you are not confident exists.
+4. `scope` — explicit in-scope / out-of-scope bullets.
+5. `questions` — 3–7 specific questions the author must answer before drafting. Each has `id` (kebab-case), `text`, optional `why`. These uncover personal experience, code samples, and opinions the model cannot supply.
+6. `outline` — ordered list of section headings in Korean.
+7. `claim_categories` — labels for types of claims this post will make (e.g. `spec`, `benchmark`, `personal-experience`, `opinion`). Used later for risk tagging.
+
+## Guardrails
+- Prefer uncertainty over confident hallucination.
+- Every technical claim in later stages will be tagged `[SUPPORTED:<source>]` or `[ASSUMED]`; design the outline so supported claims dominate.
+- Korean output for goal/learning_brief/outline/questions text; English keys and ids.

--- a/tools/blogflow/blogflow/prompts_tpl/draft.md.j2
+++ b/tools/blogflow/blogflow/prompts_tpl/draft.md.j2
@@ -1,0 +1,54 @@
+You are drafting a Korean technical blog post for {{ author }}. Return a JSON object matching the schema supplied via `--json-schema`.
+
+## Topic
+{{ session.topic }}
+
+## Brief (from prior stage)
+- Goal: {{ brief.goal }}
+- Learning brief: {{ brief.learning_brief }}
+- Scope: {{ brief.scope or '(not specified)' }}
+
+### Source pack
+{%- for s in brief.source_pack or [] %}
+- {{ s.get('label', '') }}{% if s.get('url') %} — {{ s.get('url') }}{% endif %}{% if s.get('note') %} ({{ s.get('note') }}){% endif %}
+{%- else %}
+- (none)
+{%- endfor %}
+
+### Outline
+{%- for h in brief.outline or [] %}
+{{ loop.index }}. {{ h }}
+{%- endfor %}
+
+### Claim categories
+{{ brief.claim_categories | default([]) | join(', ') or '(unspecified)' }}
+
+## Author answers
+{%- for q in brief.questions or [] %}
+- **{{ q.id }}**: {{ q.text }}
+  Answer: {{ answers.get(q.id, '(no answer — treat as unknown)') }}
+{%- endfor %}
+
+{% if prior_review is defined and prior_review %}
+## Reviewer feedback (address ONLY the blocking items)
+The previous draft came back with `GATE: {{ session.review_gate | upper }}`. The reviewer's output has two sections: `Required fixes (blocking)` and `Suggestions (non-blocking)`. **Apply only the Required-fixes items.** Ignore the Suggestions section — the author will handle those manually. Do not soften wording globally; only rewrite the sentences the reviewer quoted.
+
+```
+{{ prior_review }}
+```
+{% endif %}
+
+## What to produce
+- `title_candidates` — 3 Korean title options.
+- `description_candidates` — 3 one-sentence descriptions (<= 160 chars).
+- `body_markdown` — the full post body in Korean markdown. Use `##` for top-level sections (no H1 — mkdocs renders title separately). Code fences with language tags. Tables where appropriate.
+- `claim_summary` — for each non-trivial technical claim: `claim`, `status` (SUPPORTED|ASSUMED|UNCERTAIN), `source` (label from source_pack or "personal-experience").
+- `references` — label + url list, deduped.
+- `known_risks` — bullet list of things reviewers should double-check.
+
+## Guardrails (hard requirements)
+- Prefer uncertainty over confident hallucination. If a fact is unclear, mark `[ASSUMED]` inline AND in `claim_summary`.
+- Every technical claim MUST end with `[SUPPORTED:<label>]` or `[ASSUMED]` inline in the markdown.
+- Do not invent RFC numbers, version numbers, benchmark figures, or historical dates. If you cannot verify, write prose that names the uncertainty.
+- Keep personal-experience claims first-person and concrete (avoid "많은 사람들이…").
+- Korean prose. English proper nouns, code, and commands.

--- a/tools/blogflow/blogflow/prompts_tpl/finalize.md.j2
+++ b/tools/blogflow/blogflow/prompts_tpl/finalize.md.j2
@@ -1,0 +1,33 @@
+You are finalizing a Korean technical blog post. Merge the DRAFT, REVIEW feedback, and (if present) AUTHOR REFLECTION into a single publish-ready markdown body.
+
+## Topic
+{{ session.topic }}
+
+## Draft body (current)
+---
+{{ draft.body_markdown }}
+---
+
+## Review feedback
+---
+{{ review.raw }}
+---
+
+## Author reflection (optional)
+{% if reflection %}
+---
+{{ reflection }}
+---
+{% else %}
+(author opted to skip)
+{% endif %}
+
+## Instructions
+- **Apply every item in the review's `Required fixes (blocking)` section** that does not conflict with the author's brief/intent. Rewrite only the exact sentences the reviewer quoted.
+- **Ignore the review's `Suggestions (non-blocking)` section.** The author handles those manually after publish — do not apply them here.
+- Preserve the draft's voice and structure. No wholesale rewrites, no new section-level reorganization.
+- **Strip all internal provenance markers** from the prose: remove every `[SUPPORTED:<label>]` and every `[ASSUMED]` tag. They are internal auditing aids and must not appear in the published post. Do NOT replace them with footnotes — just delete them and tidy the surrounding whitespace so the sentence reads naturally.
+- Keep the references/bibliography section at the bottom of the post intact (if present), so readers still see external links.
+- If the author reflection is present, weave a short closing subsection titled `## 회고` using it verbatim (light edits ok for tone but preserve meaning).
+- Output markdown body ONLY. No frontmatter. No commentary. No ` ``` ` fences around the whole document.
+- Start directly with a `##` heading — do NOT emit an H1.

--- a/tools/blogflow/blogflow/prompts_tpl/ideas.md.j2
+++ b/tools/blogflow/blogflow/prompts_tpl/ideas.md.j2
@@ -1,0 +1,21 @@
+You are helping {{ author }} brainstorm technical blog post ideas for a Korean personal blog (mkdocs material). Your output MUST match the JSON schema supplied via `--json-schema`.
+
+## Author context
+- Blog: bnbong.github.io (Korean, technical, MkDocs Material)
+- Default category: {{ default_category }}
+{%- if category %}
+- Requested focus category: {{ category }}
+{%- endif %}
+- Recent post titles (avoid duplicates, ok to extend):
+{%- for t in recent_titles %}
+  - {{ t }}
+{%- endfor %}
+
+## Instructions
+- Produce {{ count }} distinct, specific post ideas.
+- Prefer topics where {{ author }} has hands-on experience or can produce verifiable references.
+- Rank by freshness (why publish NOW?) and hallucination risk.
+- Each idea needs: title, why_now, audience, difficulty (intro|intermediate|advanced), source_requirements (what links/docs must be cited), hallucination_risk (low|medium|high + 1-line rationale), single_or_series (single|series-<N>).
+- Prefer uncertainty over confident hallucination. If an idea would require sources you cannot reliably cite, mark hallucination_risk=high and say so.
+
+Return ONLY a JSON object matching the schema — no prose, no markdown fences.

--- a/tools/blogflow/blogflow/prompts_tpl/reflection.md.j2
+++ b/tools/blogflow/blogflow/prompts_tpl/reflection.md.j2
@@ -1,0 +1,12 @@
+You are preparing a brief reflection prompt for {{ author }}. This is the author's own voice — answer as yourself, not as an assistant.
+
+## Topic
+{{ session.topic }}
+
+## Why this stage exists
+After the review pass, write a short reflection on:
+- What did you learn while writing this post?
+- Which reviewer points genuinely surprised you?
+- Anything you now see differently about {{ session.topic }}?
+
+Keep it 3–8 sentences. Korean prose. First-person. Skip if nothing new came up — an honest skip beats a forced reflection.

--- a/tools/blogflow/blogflow/prompts_tpl/review.md.j2
+++ b/tools/blogflow/blogflow/prompts_tpl/review.md.j2
@@ -1,0 +1,73 @@
+You are a **ship-oriented gatekeeper** for a Korean engineering blog. Your job is to decide whether a DRAFT is safe to publish — not to polish it. The author has limited time and is re-running this review at a per-cycle token cost, so do not invent work.
+
+## Topic
+{{ session.topic }}
+
+## Brief goal
+{{ brief.goal }}
+
+## Claim categories expected
+{{ brief.claim_categories | default([]) | join(', ') or '(unspecified)' }}
+
+## Source pack available to the author
+{%- for s in brief.source_pack or [] %}
+- {{ s.get('label', '') }}{% if s.get('url') %} — {{ s.get('url') }}{% endif %}
+{%- else %}
+- (none)
+{%- endfor %}
+
+## Draft under review
+---
+{{ draft.body_markdown }}
+---
+
+## Author-declared claim summary
+{%- for c in draft.claim_summary or [] %}
+- [{{ c.get('status', '?') }}] {{ c.get('claim', '') }} (source: {{ c.get('source', '?') }})
+{%- else %}
+- (none declared)
+{%- endfor %}
+
+## Author-declared known risks
+{%- for r in draft.known_risks or [] %}
+- {{ r }}
+{%- else %}
+- (none declared)
+{%- endfor %}
+
+## What counts as a BLOCKING issue
+Only these three categories ever justify `REVISE` or `BLOCK`:
+
+1. **Hallucination** — invented RFC numbers, fake dates, non-existent versions, fabricated quotes, made-up benchmarks.
+2. **Factually wrong claim** — the claim is false, not merely unsourced. (e.g., "IPv4 headers are 24 bytes" is wrong; "TCP sends segments, UDP sends datagrams" being swapped is wrong.)
+3. **Logical contradiction or critical gap** — the draft contradicts itself, or skips a step so large that a target-audience reader genuinely cannot follow.
+
+**NOT blocking** (put under `## Suggestions` instead):
+- Widely-used technical terms without a source in the source pack (e.g., "best-effort delivery", "MTU", "VLSM", "NAT"). These are industry-standard vocabulary; the `[ASSUMED]` tag is sufficient.
+- Requests to soften wording, add caveats, or switch between "흔히" and "항상".
+- Style, formatting, header casing, Korean/English term pairing, emoji choices.
+- "Could add more examples", "could be clearer", "could split this section".
+- Scope opinions ("this section is too long / out of scope"). Author already chose the scope.
+
+If you only find non-blocking items, the gate is `APPROVED`. That is the **default outcome**, not the exception.
+
+## Output structure
+
+### Required fixes (blocking)
+A numbered list of **only** the items that fall into the three blocking categories above. Quote the exact offending sentence. If there are none, write:
+
+> None — draft is factually safe to publish.
+
+### Suggestions (non-blocking, author's discretion)
+A numbered list of smaller polish items the author may apply or ignore. Keep this section tight; do not pad it. This section does not affect the gate.
+
+## GATE decision (MANDATORY)
+The VERY LAST line of your output MUST be EXACTLY one of:
+
+- `GATE: APPROVED` — no blocking issues (the expected default)
+- `GATE: REVISE` — one or more blocking issues exist and can be fixed by rewriting specific sentences
+- `GATE: BLOCK` — pervasive factual problems that require re-doing the draft
+
+No punctuation after the decision word. No prose after the gate line.
+
+If the Required-fixes section is "None", the gate MUST be `APPROVED`.

--- a/tools/blogflow/blogflow/publish.py
+++ b/tools/blogflow/blogflow/publish.py
@@ -1,0 +1,93 @@
+"""Publish-phase file operations. Writes to the target post file but never touches Git."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from . import frontmatter as fm_mod
+from .errors import PublishError
+from .models import Frontmatter
+
+
+def validate_post_path(repo_root: Path, rel_path: str) -> Path:
+    """Ensure the target post path lives under docs/blog/posts/ and ends with .md."""
+    blog_root = (repo_root / "docs" / "blog" / "posts").resolve()
+    target = (repo_root / rel_path).resolve()
+    try:
+        target.relative_to(blog_root)
+    except ValueError as exc:
+        raise PublishError(
+            f"Post path {rel_path!r} must live under docs/blog/posts/."
+        ) from exc
+    if target.suffix != ".md":
+        raise PublishError(f"Post path {rel_path!r} must have a .md extension.")
+    return target
+
+
+def build_skeleton(topic: str, *, today: date, author: str) -> Frontmatter:
+    return Frontmatter(
+        raw={
+            "title": topic,
+            "description": topic,
+            "authors": [author],
+            "date": {"created": today.isoformat(), "updated": today.isoformat()},
+            "categories": [],
+            "tags": [],
+            "comments": True,
+        },
+        body="",
+    )
+
+
+def merge_final_into_post(
+    post_path: Path,
+    final_body: str,
+    *,
+    today: date,
+    ensure_draft_false: bool,
+    topic: str,
+    author: str,
+) -> None:
+    if post_path.exists():
+        fm = fm_mod.read(post_path)
+    else:
+        fm = build_skeleton(topic, today=today, author=author)
+    fm.body = final_body.lstrip("\n")
+    fm.ensure_published(today=today, ensure_draft_false=ensure_draft_false)
+    fm_mod.write_atomic(post_path, fm)
+
+
+def suggested_git_commands(post_path: Path, session_dir_rel: str) -> list[str]:
+    rel_post = post_path.as_posix()
+    return [
+        f"git add {rel_post} {session_dir_rel}",
+        f'git commit -m "post: $(basename {rel_post} .md)"',
+        "git push origin master",
+    ]
+
+
+def guard_publish(
+    *,
+    status: str,
+    expected_status: str,
+    target_post_path: str | None,
+    final_path: Path,
+) -> None:
+    if status != expected_status:
+        raise PublishError(
+            f"Session must be {expected_status!r}, got {status!r}. Run `blogflow approve` first."
+        )
+    if not target_post_path:
+        raise PublishError(
+            "Session has no target_post_path set. Use `blogflow init --post-path ...` next time."
+        )
+    if not final_path.exists():
+        raise PublishError(
+            f"Final output not found at {final_path}. Run `blogflow finalize` first."
+        )
+
+
+def _unused(_: Any) -> None:  # pragma: no cover
+    pass

--- a/tools/blogflow/blogflow/publish.py
+++ b/tools/blogflow/blogflow/publish.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -11,15 +12,26 @@ from .errors import PublishError
 from .models import Frontmatter
 
 
-def validate_post_path(repo_root: Path, rel_path: str) -> Path:
-    """Ensure the target post path lives under docs/blog/posts/ and ends with .md."""
-    blog_root = (repo_root / "docs" / "blog" / "posts").resolve()
+DEFAULT_BLOG_DIR = "docs/blog/posts"
+
+
+def validate_post_path(
+    repo_root: Path, rel_path: str, blog_dir: str = DEFAULT_BLOG_DIR
+) -> Path:
+    """Ensure the target post path lives under the configured blog dir and ends with .md.
+
+    ``blog_dir`` defaults to ``docs/blog/posts`` for callers that do not thread
+    the full config through (e.g. unit tests). Callers that have access to
+    ``ctx.config`` should pass ``config["blog_dir"]`` so that overriding
+    ``blog_dir`` in ``.blogflow/config.yaml`` actually takes effect.
+    """
+    blog_root = (repo_root / blog_dir).resolve()
     target = (repo_root / rel_path).resolve()
     try:
         target.relative_to(blog_root)
     except ValueError as exc:
         raise PublishError(
-            f"Post path {rel_path!r} must live under docs/blog/posts/."
+            f"Post path {rel_path!r} must live under {blog_dir}/."
         ) from exc
     if target.suffix != ".md":
         raise PublishError(f"Post path {rel_path!r} must have a .md extension.")
@@ -49,23 +61,62 @@ def merge_final_into_post(
     ensure_draft_false: bool,
     topic: str,
     author: str,
+    update_updated_date: bool = True,
 ) -> None:
     if post_path.exists():
         fm = fm_mod.read(post_path)
     else:
         fm = build_skeleton(topic, today=today, author=author)
     fm.body = final_body.lstrip("\n")
-    fm.ensure_published(today=today, ensure_draft_false=ensure_draft_false)
+    fm.ensure_published(
+        today=today,
+        ensure_draft_false=ensure_draft_false,
+        update_updated_date=update_updated_date,
+    )
     fm_mod.write_atomic(post_path, fm)
 
 
-def suggested_git_commands(post_path: Path, session_dir_rel: str) -> list[str]:
+def suggested_git_commands(
+    post_path: Path,
+    session_dir_rel: str,
+    *,
+    repo_root: Path | None = None,
+) -> list[str]:
+    """Return copy-pasteable `git add / commit / push` suggestions.
+
+    The push command targets whatever branch the repo is currently on. If we
+    can't detect the branch (no git, detached HEAD, repo_root not passed), we
+    emit a bare `git push` so the user's tracking config decides — much safer
+    than hardcoding `master`/`main` and misleading users on the other layout.
+    """
     rel_post = post_path.as_posix()
+    branch = _detect_current_branch(repo_root) if repo_root else None
+    push_cmd = f"git push origin {branch}" if branch else "git push"
     return [
         f"git add {rel_post} {session_dir_rel}",
         f'git commit -m "post: $(basename {rel_post} .md)"',
-        "git push origin master",
+        push_cmd,
     ]
+
+
+def _detect_current_branch(repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    # `HEAD` means detached — no branch to push to.
+    if not branch or branch == "HEAD":
+        return None
+    return branch
 
 
 def guard_publish(
@@ -81,7 +132,9 @@ def guard_publish(
         )
     if not target_post_path:
         raise PublishError(
-            "Session has no target_post_path set. Use `blogflow init --post-path ...` next time."
+            "Session has no target_post_path set. Either re-run publish with "
+            "`blogflow publish --post-path <docs/blog/posts/...>` to set it "
+            "retroactively, or pass `--post-path` to `blogflow init` next time."
         )
     if not final_path.exists():
         raise PublishError(

--- a/tools/blogflow/blogflow/schemas.py
+++ b/tools/blogflow/blogflow/schemas.py
@@ -1,0 +1,118 @@
+"""JSON Schema constants used with `claude --json-schema`."""
+
+from __future__ import annotations
+
+IDEAS_SCHEMA: dict = {
+    "type": "object",
+    "required": ["ideas"],
+    "additionalProperties": False,
+    "properties": {
+        "ideas": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["title", "why_now", "audience", "difficulty"],
+                "additionalProperties": True,
+                "properties": {
+                    "title": {"type": "string"},
+                    "why_now": {"type": "string"},
+                    "audience": {"type": "string"},
+                    "difficulty": {"type": "string"},
+                    "source_requirements": {"type": "string"},
+                    "hallucination_risk": {"type": "string"},
+                    "single_or_series": {"type": "string"},
+                },
+            },
+        }
+    },
+}
+
+BRIEF_SCHEMA: dict = {
+    "type": "object",
+    "required": ["goal", "learning_brief", "questions", "outline"],
+    "additionalProperties": True,
+    "properties": {
+        "goal": {"type": "string"},
+        "learning_brief": {"type": "string"},
+        "source_pack": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["label"],
+                "properties": {
+                    "label": {"type": "string"},
+                    "url": {"type": "string"},
+                    "note": {"type": "string"},
+                },
+            },
+        },
+        "scope": {"type": "string"},
+        "questions": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["id", "text"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "text": {"type": "string"},
+                    "why": {"type": "string"},
+                },
+            },
+        },
+        "outline": {"type": "array", "items": {"type": "string"}},
+        "claim_categories": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+DRAFT_SCHEMA: dict = {
+    "type": "object",
+    "required": ["title_candidates", "description_candidates", "body_markdown"],
+    "additionalProperties": True,
+    "properties": {
+        "title_candidates": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+        },
+        "description_candidates": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+        },
+        "body_markdown": {"type": "string", "minLength": 1},
+        "claim_summary": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "claim": {"type": "string"},
+                    "status": {"type": "string"},
+                    "source": {"type": "string"},
+                },
+            },
+        },
+        "references": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "label": {"type": "string"},
+                    "url": {"type": "string"},
+                },
+            },
+        },
+        "known_risks": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+SCHEMA_REGISTRY: dict[str, dict] = {
+    "ideas": IDEAS_SCHEMA,
+    "brief": BRIEF_SCHEMA,
+    "draft": DRAFT_SCHEMA,
+}
+
+
+def get(name: str) -> dict:
+    return SCHEMA_REGISTRY[name]

--- a/tools/blogflow/blogflow/state.py
+++ b/tools/blogflow/blogflow/state.py
@@ -212,7 +212,12 @@ def load_config(repo_root: Path) -> dict[str, Any]:
             f".blogflow/config.yaml not found under {repo_root}. "
             "Run blogflow from the repo root."
         )
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        # Surface malformed config as BlogflowError so the CLI wrapper formats
+        # a clean `error: ...` line instead of leaking a PyYAML traceback.
+        raise ConfigError(f"{path} is not valid YAML: {exc}") from exc
     if not isinstance(data, dict):
         raise ConfigError(".blogflow/config.yaml must be a YAML mapping.")
     return data

--- a/tools/blogflow/blogflow/state.py
+++ b/tools/blogflow/blogflow/state.py
@@ -1,0 +1,246 @@
+"""Session state and workflow state-machine."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .errors import ConfigError, SessionNotFoundError, StateError
+
+STATUS_INITIATED = "initiated"
+STATUS_BRIEF_READY = "brief_ready"
+STATUS_AWAITING_ANSWERS = "awaiting_answers"
+STATUS_DRAFT_READY = "draft_ready"
+STATUS_UNDER_REVIEW = "under_review"
+STATUS_AWAITING_REFLECTION = "awaiting_reflection"
+STATUS_FINAL_READY = "final_ready"
+STATUS_APPROVED = "approved"
+STATUS_PUBLISHED = "published"
+
+ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    STATUS_INITIATED: {STATUS_BRIEF_READY},
+    STATUS_BRIEF_READY: {STATUS_AWAITING_ANSWERS},
+    STATUS_AWAITING_ANSWERS: {STATUS_DRAFT_READY},
+    STATUS_DRAFT_READY: {STATUS_UNDER_REVIEW},
+    STATUS_UNDER_REVIEW: {STATUS_AWAITING_REFLECTION, STATUS_DRAFT_READY},
+    STATUS_AWAITING_REFLECTION: {STATUS_FINAL_READY},
+    STATUS_FINAL_READY: {STATUS_APPROVED},
+    STATUS_APPROVED: {STATUS_PUBLISHED},
+    STATUS_PUBLISHED: set(),
+}
+
+NEXT_COMMAND_HINT: dict[str, str] = {
+    STATUS_INITIATED: "blogflow brief",
+    STATUS_BRIEF_READY: "blogflow answer",
+    STATUS_AWAITING_ANSWERS: "blogflow answer",
+    STATUS_DRAFT_READY: "blogflow draft",
+    STATUS_UNDER_REVIEW: "blogflow review",
+    STATUS_AWAITING_REFLECTION: "blogflow reflection",
+    STATUS_FINAL_READY: "blogflow finalize",
+    STATUS_APPROVED: "blogflow publish",
+    STATUS_PUBLISHED: "(workflow complete)",
+}
+
+
+SLUG_RE = re.compile(r"[^a-zA-Z0-9가-힣\-]+")
+
+
+def slugify(topic: str) -> str:
+    slug = SLUG_RE.sub("-", topic.strip().lower()).strip("-")
+    return slug[:60] or "post"
+
+
+def new_session_id(
+    topic: str,
+    *,
+    now: datetime | None = None,
+    existing: set[str] | list[str] | None = None,
+) -> str:
+    """Build a session id. If ``existing`` is supplied and the base id collides,
+    append ``-2``, ``-3``, ... until a unique id is produced."""
+    now = now or datetime.now()
+    base = f"{now.strftime('%Y%m%d-%H%M')}-{slugify(topic)}"
+    if not existing:
+        return base
+    taken = set(existing)
+    if base not in taken:
+        return base
+    n = 2
+    while f"{base}-{n}" in taken:
+        n += 1
+    return f"{base}-{n}"
+
+
+@dataclass
+class Session:
+    id: str
+    topic: str
+    slug: str
+    status: str = STATUS_INITIATED
+    target_post_path: str | None = None
+    # Microsecond precision — seconds-only timestamps collided when two sessions
+    # were saved in the same wall-clock second and resolve_latest() then picked
+    # the wrong one. Legacy sessions with seconds-only strings still sort
+    # correctly against newer microsecond strings (microsecond strings compare
+    # greater under lexicographic ordering).
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    approved_at: str | None = None
+    published_at: str | None = None
+    review_gate: str | None = None
+    reflection_skipped: bool = False
+    # Count of auto revise-loops taken so far. Incremented each time a Codex
+    # review returns REVISE/BLOCK and the session loops back to draft_ready.
+    # After MAX_AUTO_REVISE the loop stops auto-transitioning; the author must
+    # manually decide with `blogflow review --gate ...`.
+    revise_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Session":
+        known = {f for f in cls.__dataclass_fields__}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+
+def transition(session: Session, target: str) -> None:
+    """Mutate `session.status` after verifying the transition is legal."""
+    current = session.status
+    if target == current:
+        return
+    allowed = ALLOWED_TRANSITIONS.get(current, set())
+    if target not in allowed:
+        hint = NEXT_COMMAND_HINT.get(current)
+        raise StateError(
+            f"Illegal transition {current!r} → {target!r}. "
+            f"Next expected step for state {current!r}: {hint}",
+            expected_command=hint,
+        )
+    session.status = target
+    session.updated_at = datetime.now().isoformat()
+
+
+class SessionStore:
+    """Filesystem-backed session store under .blogflow/sessions/."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+
+    def sessions_dir(self) -> Path:
+        return self.root / ".blogflow" / "sessions"
+
+    def session_path(self, session_id: str) -> Path:
+        return self.sessions_dir() / session_id
+
+    def session_file(self, session_id: str) -> Path:
+        return self.session_path(session_id) / "session.yaml"
+
+    def list_sessions(self) -> list[str]:
+        d = self.sessions_dir()
+        if not d.exists():
+            return []
+        return sorted(p.name for p in d.iterdir() if p.is_dir())
+
+    def create(self, session: Session) -> Path:
+        path = self.session_path(session.id)
+        if self.session_file(session.id).exists():
+            raise StateError(
+                f"Session id {session.id!r} already exists at {path}. "
+                f"Re-run `blogflow init` (a suffix will be appended) or pick a different topic."
+            )
+        for sub in ("prompts", "outputs", "user", "schemas", "logs"):
+            (path / sub).mkdir(parents=True, exist_ok=True)
+        self.save(session)
+        return path
+
+    def load(self, session_id: str) -> Session:
+        f = self.session_file(session_id)
+        if not f.exists():
+            raise SessionNotFoundError(f"No session found: {session_id}")
+        data = yaml.safe_load(f.read_text(encoding="utf-8")) or {}
+        return Session.from_dict(data)
+
+    def save(self, session: Session) -> None:
+        session.updated_at = datetime.now().isoformat()
+        f = self.session_file(session.id)
+        f.parent.mkdir(parents=True, exist_ok=True)
+        text = yaml.safe_dump(session.to_dict(), sort_keys=False, allow_unicode=True)
+        _atomic_write(f, text)
+
+    def resolve_latest(self, explicit: str | None = None) -> Session:
+        if explicit:
+            return self.load(explicit)
+        ids = self.list_sessions()
+        if not ids:
+            raise SessionNotFoundError(
+                'No sessions found. Start one with `blogflow init --topic "..."`.'
+            )
+        candidates = []
+        for sid in ids:
+            try:
+                s = self.load(sid)
+                candidates.append(s)
+            except SessionNotFoundError:
+                continue
+        if not candidates:
+            raise SessionNotFoundError("No valid sessions.")
+        # Tie-break on created_at, then id (lexicographic on minute-precision id
+        # is still better than nothing). Without tie-breakers, two sessions
+        # saved in the same second (common when you init B right after A's last
+        # transition) compared equal and Python's stable sort returned
+        # whichever happened to be listed first.
+        candidates.sort(
+            key=lambda s: (s.updated_at, s.created_at, s.id),
+            reverse=True,
+        )
+        return candidates[0]
+
+
+def load_config(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / ".blogflow" / "config.yaml"
+    if not path.exists():
+        raise ConfigError(
+            f".blogflow/config.yaml not found under {repo_root}. "
+            "Run blogflow from the repo root."
+        )
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ConfigError(".blogflow/config.yaml must be a YAML mapping.")
+    return data
+
+
+def find_repo_root(start: Path | None = None) -> Path:
+    """Walk up from `start` looking for `.blogflow/config.yaml` or `mkdocs.yml`."""
+    cur = (start or Path.cwd()).resolve()
+    for parent in [cur, *cur.parents]:
+        if (parent / ".blogflow" / "config.yaml").exists():
+            return parent
+        if (parent / "mkdocs.yml").exists():
+            return parent
+    raise ConfigError(
+        "Could not locate repo root (no .blogflow/config.yaml or mkdocs.yml found in parents)."
+    )
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise

--- a/tools/blogflow/pyproject.toml
+++ b/tools/blogflow/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "blogflow"
+dynamic = ["version"]
+description = "Local editorial workflow CLI for bnbong's MkDocs blog — orchestrates Claude and Codex with approval gates"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "bnbong", email = "bbbong9@gmail.com" }]
+license = { text = "MIT" }
+dependencies = [
+    "click>=8.1",
+    "Jinja2>=3.1",
+    "PyYAML>=6.0",
+]
+
+[tool.setuptools.dynamic]
+version = { attr = "blogflow.__version__" }
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[project.scripts]
+blogflow = "blogflow.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["blogflow*"]
+
+[tool.setuptools.package-data]
+"blogflow" = ["prompts_tpl/*.j2", "schemas_data/*.json"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/tools/blogflow/tests/conftest.py
+++ b/tools/blogflow/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    """A temp directory laid out like the real repo: mkdocs.yml + .blogflow/config.yaml."""
+    (tmp_path / "mkdocs.yml").write_text("site_name: test\n", encoding="utf-8")
+    blog_dir = tmp_path / "docs" / "blog" / "posts"
+    blog_dir.mkdir(parents=True)
+    config = {
+        "author": "bnbong",
+        "blog_dir": "docs/blog/posts",
+        "default_category": "Computer Science",
+        "claude": {"model": None, "timeout_sec": 10},
+        "codex": {
+            "model": None,
+            "sandbox_review": "read-only",
+            "sandbox_exec": "workspace-write",
+            "timeout_sec": 10,
+        },
+        "publish": {"update_updated_date": True, "ensure_draft_false": True},
+    }
+    blogflow_dir = tmp_path / ".blogflow"
+    blogflow_dir.mkdir()
+    (blogflow_dir / "config.yaml").write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def sample_post(repo_root: Path) -> Path:
+    post = repo_root / "docs" / "blog" / "posts" / "20250101" / "sample.md"
+    post.parent.mkdir(parents=True, exist_ok=True)
+    post.write_text(
+        """---
+title: Sample Post
+description: A sample post
+authors: [bnbong]
+date:
+  created: 2025-01-01
+  updated: 2025-01-01
+categories:
+  - Test
+tags:
+  - sample
+comments: true
+---
+
+Hello, world.
+""",
+        encoding="utf-8",
+    )
+    return post

--- a/tools/blogflow/tests/test_adapters.py
+++ b/tools/blogflow/tests/test_adapters.py
@@ -5,6 +5,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from blogflow.adapters import base as base_mod
 from blogflow.adapters.claude import ClaudeAdapter
 from blogflow.adapters.codex import (
@@ -15,6 +17,7 @@ from blogflow.adapters.codex import (
     CodexAdapter,
     parse_gate,
 )
+from blogflow.errors import AdapterError
 
 
 def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
@@ -226,6 +229,29 @@ def test_codex_adapter_skips_effort_flag_when_none(tmp_path: Path):
         adapter.run("prompt", log_dir=tmp_path / "logs", stage="draft")
     called_cmd = mock_run.call_args.args[0]
     assert not any(a.startswith("model_reasoning_effort=") for a in called_cmd)
+
+
+def test_invoke_raises_adapter_error_when_binary_missing(tmp_path: Path):
+    """A missing `claude` / `codex` binary used to bubble up as a raw
+    FileNotFoundError traceback — breaks first-run UX on machines that don't
+    have both CLIs installed. Must surface as AdapterError with an actionable
+    hint so the top-level CLI wrapper formats it cleanly."""
+    with patch.object(base_mod.subprocess, "run", side_effect=FileNotFoundError()):
+        with pytest.raises(AdapterError) as exc_info:
+            base_mod.invoke(
+                ["nonexistent-binary"],
+                stdin_text=None,
+                timeout_sec=None,
+                log_dir=tmp_path / "logs",
+                stage="brief",
+                adapter_name="claude",
+            )
+    msg = str(exc_info.value)
+    assert "nonexistent-binary" in msg
+    assert "PATH" in msg
+    # Log file must still be written so the failure is auditable.
+    logs = list((tmp_path / "logs").glob("brief-claude-*.log"))
+    assert len(logs) == 1
 
 
 def test_parse_gate_variants():

--- a/tools/blogflow/tests/test_adapters.py
+++ b/tools/blogflow/tests/test_adapters.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from blogflow.adapters import base as base_mod
+from blogflow.adapters.claude import ClaudeAdapter
+from blogflow.adapters.codex import (
+    GATE_APPROVED,
+    GATE_BLOCK,
+    GATE_REVISE,
+    GATE_UNCLEAR,
+    CodexAdapter,
+    parse_gate,
+)
+
+
+def _fake_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_invoke_writes_log(tmp_path: Path):
+    with patch.object(base_mod.subprocess, "run", return_value=_fake_completed("hi")):
+        proc, dur = base_mod.invoke(
+            ["fake"],
+            stdin_text="prompt",
+            timeout_sec=5,
+            log_dir=tmp_path / "logs",
+            stage="brief",
+            adapter_name="claude",
+        )
+    assert proc.stdout == "hi"
+    logs = list((tmp_path / "logs").glob("brief-claude-*.log"))
+    assert len(logs) == 1
+    content = logs[0].read_text(encoding="utf-8")
+    assert "exit_code: 0" in content
+    assert "hi" in content
+
+
+def test_claude_adapter_parses_json_result(tmp_path: Path):
+    schema = {
+        "type": "object",
+        "required": ["x"],
+        "properties": {"x": {"type": "string"}},
+    }
+    envelope = {"type": "result", "result": json.dumps({"x": "ok"})}
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed(json.dumps(envelope))
+    ) as mock_run:
+        adapter = ClaudeAdapter(timeout_sec=5)
+        result = adapter.run(
+            "prompt",
+            schema=schema,
+            log_dir=tmp_path / "logs",
+            stage="brief",
+        )
+    assert result.ok
+    assert result.parsed == {"x": "ok"}
+    # `--json-schema` must carry the inline JSON (not a file path) so the
+    # claude CLI can parse it — passing a path causes the CLI to hang.
+    called_cmd = mock_run.call_args.args[0]
+    assert "--json-schema" in called_cmd
+    schema_arg = called_cmd[called_cmd.index("--json-schema") + 1]
+    assert json.loads(schema_arg) == schema
+    assert "--output-format" in called_cmd and "json" in called_cmd
+
+
+def test_claude_adapter_reads_structured_output_field(tmp_path: Path):
+    """When --json-schema is used, the validated payload lives in
+    `structured_output`, not `result` (which is empty). The adapter must
+    pick up the right field or downstream stages see an empty brief."""
+    schema = {"type": "object", "required": ["goal"], "properties": {"goal": {"type": "string"}}}
+    envelope = {
+        "type": "result",
+        "result": "",
+        "structured_output": {"goal": "understand IPv4"},
+    }
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed(json.dumps(envelope))
+    ):
+        adapter = ClaudeAdapter(timeout_sec=5)
+        result = adapter.run(
+            "prompt",
+            schema=schema,
+            log_dir=tmp_path / "logs",
+            stage="brief",
+        )
+    assert result.ok
+    assert result.parsed == {"goal": "understand IPv4"}
+
+
+def test_claude_adapter_disables_timeout_when_none(tmp_path: Path):
+    """`timeout_sec=None` (blogflow's default) must pass `timeout=None` to
+    subprocess, not a number — LLM turns vary wildly and users rely on
+    Ctrl+C, not a hard ceiling."""
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed('{"result":"ok"}')
+    ) as mock_run:
+        adapter = ClaudeAdapter(timeout_sec=None)
+        adapter.run("prompt", log_dir=tmp_path / "logs", stage="brief")
+    assert mock_run.call_args.kwargs["timeout"] is None
+
+
+def test_codex_adapter_disables_timeout_when_none(tmp_path: Path):
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed("text")
+    ) as mock_run:
+        adapter = CodexAdapter(timeout_sec=None)
+        adapter.run("prompt", log_dir=tmp_path / "logs", stage="review",
+                    extra={"mode": "review"})
+    assert mock_run.call_args.kwargs["timeout"] is None
+
+
+def test_claude_adapter_handles_nonzero_exit(tmp_path: Path):
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed("", "boom", 2)
+    ):
+        adapter = ClaudeAdapter(timeout_sec=5)
+        result = adapter.run("prompt", log_dir=tmp_path / "logs", stage="brief")
+    assert not result.ok
+    assert result.exit_code == 2
+    assert "boom" in result.stderr
+
+
+def test_claude_adapter_without_schema_returns_text(tmp_path: Path):
+    envelope = {"result": "plain text"}
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed(json.dumps(envelope))
+    ):
+        adapter = ClaudeAdapter(timeout_sec=5)
+        result = adapter.run("prompt", log_dir=tmp_path / "logs", stage="finalize")
+    assert result.ok
+    assert result.text == "plain text"
+    assert result.parsed is None
+
+
+def test_codex_adapter_exec_default_sandbox(tmp_path: Path):
+    with patch.object(
+        base_mod.subprocess,
+        "run",
+        return_value=_fake_completed("review text\nGATE: APPROVED"),
+    ) as mock_run:
+        adapter = CodexAdapter(timeout_sec=5)
+        result = adapter.run("prompt", log_dir=tmp_path / "logs", stage="review")
+    called_cmd = mock_run.call_args.args[0]
+    assert called_cmd[:2] == ["codex", "exec"]
+    assert "-s" in called_cmd and "workspace-write" in called_cmd
+    assert result.ok
+    assert "GATE: APPROVED" in result.text
+
+
+def test_codex_adapter_review_mode_uses_read_only(tmp_path: Path):
+    """Issue 1: `mode=review` must pick the read-only sandbox but still use `codex exec`."""
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed("text\nGATE: REVISE")
+    ) as mock_run:
+        adapter = CodexAdapter(timeout_sec=5, sandbox_review="read-only")
+        adapter.run(
+            "prompt",
+            log_dir=tmp_path / "logs",
+            stage="review",
+            extra={"mode": "review"},
+        )
+    called_cmd = mock_run.call_args.args[0]
+    assert called_cmd[:2] == ["codex", "exec"]
+    # -s read-only must appear and workspace-write must NOT be used
+    assert "-s" in called_cmd
+    assert "read-only" in called_cmd
+    assert "workspace-write" not in called_cmd
+
+
+def test_codex_adapter_exec_mode_uses_workspace_write(tmp_path: Path):
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed("text")
+    ) as mock_run:
+        adapter = CodexAdapter(timeout_sec=5)
+        adapter.run(
+            "prompt",
+            log_dir=tmp_path / "logs",
+            stage="draft",
+            extra={"mode": "exec"},
+        )
+    called_cmd = mock_run.call_args.args[0]
+    assert "workspace-write" in called_cmd
+    assert "read-only" not in called_cmd
+
+
+def test_codex_adapter_sets_reasoning_effort(tmp_path: Path):
+    """The user's global `~/.codex/config.toml` can default to `xhigh`, which
+    makes full-draft reviews take 10+ minutes. The adapter must emit
+    `-c model_reasoning_effort=<value>` to override that per invocation."""
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed("text\nGATE: APPROVED")
+    ) as mock_run:
+        adapter = CodexAdapter(timeout_sec=5, reasoning_effort="medium")
+        adapter.run("prompt", log_dir=tmp_path / "logs", stage="review",
+                    extra={"mode": "review"})
+    called_cmd = mock_run.call_args.args[0]
+    assert "-c" in called_cmd
+    assert "model_reasoning_effort=medium" in called_cmd
+
+
+def test_codex_adapter_skips_effort_flag_when_none(tmp_path: Path):
+    """Setting reasoning_effort=None must defer to the user's global config
+    — no `-c` override should be added."""
+    with patch.object(
+        base_mod.subprocess, "run", return_value=_fake_completed("text")
+    ) as mock_run:
+        adapter = CodexAdapter(timeout_sec=5, reasoning_effort=None)
+        adapter.run("prompt", log_dir=tmp_path / "logs", stage="draft")
+    called_cmd = mock_run.call_args.args[0]
+    assert not any(a.startswith("model_reasoning_effort=") for a in called_cmd)
+
+
+def test_parse_gate_variants():
+    assert parse_gate("stuff\nGATE: APPROVED") == GATE_APPROVED
+    assert parse_gate("stuff\nGATE: REVISE\n") == GATE_REVISE
+    assert parse_gate("stuff\nGATE: BLOCK") == GATE_BLOCK
+    assert parse_gate("no gate here") == GATE_UNCLEAR
+    # Last wins
+    assert parse_gate("GATE: APPROVED\nGATE: BLOCK") == GATE_BLOCK

--- a/tools/blogflow/tests/test_adapters.py
+++ b/tools/blogflow/tests/test_adapters.py
@@ -73,7 +73,11 @@ def test_claude_adapter_reads_structured_output_field(tmp_path: Path):
     """When --json-schema is used, the validated payload lives in
     `structured_output`, not `result` (which is empty). The adapter must
     pick up the right field or downstream stages see an empty brief."""
-    schema = {"type": "object", "required": ["goal"], "properties": {"goal": {"type": "string"}}}
+    schema = {
+        "type": "object",
+        "required": ["goal"],
+        "properties": {"goal": {"type": "string"}},
+    }
     envelope = {
         "type": "result",
         "result": "",
@@ -110,8 +114,12 @@ def test_codex_adapter_disables_timeout_when_none(tmp_path: Path):
         base_mod.subprocess, "run", return_value=_fake_completed("text")
     ) as mock_run:
         adapter = CodexAdapter(timeout_sec=None)
-        adapter.run("prompt", log_dir=tmp_path / "logs", stage="review",
-                    extra={"mode": "review"})
+        adapter.run(
+            "prompt",
+            log_dir=tmp_path / "logs",
+            stage="review",
+            extra={"mode": "review"},
+        )
     assert mock_run.call_args.kwargs["timeout"] is None
 
 
@@ -197,8 +205,12 @@ def test_codex_adapter_sets_reasoning_effort(tmp_path: Path):
         base_mod.subprocess, "run", return_value=_fake_completed("text\nGATE: APPROVED")
     ) as mock_run:
         adapter = CodexAdapter(timeout_sec=5, reasoning_effort="medium")
-        adapter.run("prompt", log_dir=tmp_path / "logs", stage="review",
-                    extra={"mode": "review"})
+        adapter.run(
+            "prompt",
+            log_dir=tmp_path / "logs",
+            stage="review",
+            extra={"mode": "review"},
+        )
     called_cmd = mock_run.call_args.args[0]
     assert "-c" in called_cmd
     assert "model_reasoning_effort=medium" in called_cmd

--- a/tools/blogflow/tests/test_cli.py
+++ b/tools/blogflow/tests/test_cli.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from blogflow.adapters.base import AdapterResult
+from blogflow.cli import cli
+
+
+def _ok_brief() -> dict:
+    return {
+        "goal": "understand",
+        "learning_brief": "brief",
+        "questions": [{"id": "q1", "text": "why?"}],
+        "outline": ["Intro"],
+        "source_pack": [{"label": "RFC", "url": "https://example"}],
+        "scope": "in: x",
+        "claim_categories": ["spec"],
+    }
+
+
+def _ok_draft() -> dict:
+    return {
+        "title_candidates": ["T"],
+        "description_candidates": ["d"],
+        "body_markdown": "## Intro\n\nhello [SUPPORTED:RFC]\n",
+        "claim_summary": [],
+        "references": [],
+        "known_risks": [],
+    }
+
+
+def _result(
+    parsed: dict | None = None, text: str = "", ok: bool = True
+) -> AdapterResult:
+    return AdapterResult(ok=ok, text=text or json.dumps(parsed or {}), parsed=parsed)
+
+
+def test_init_and_status(repo_root: Path):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+            res = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--topic",
+                    "IPv4",
+                    "--post-path",
+                    "docs/blog/posts/20260420/new.md",
+                ],
+            )
+            assert res.exit_code == 0, res.output
+            assert "Session created" in res.output
+
+            res = runner.invoke(cli, ["status"])
+            assert res.exit_code == 0, res.output
+            assert "status:   initiated" in res.output
+            assert "blogflow brief" in res.output
+
+
+def test_full_happy_path(repo_root: Path):
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        # init
+        assert (
+            runner.invoke(
+                cli,
+                [
+                    "init",
+                    "--topic",
+                    "IPv4",
+                    "--post-path",
+                    "docs/blog/posts/20260420/new.md",
+                ],
+            ).exit_code
+            == 0
+        )
+
+        # brief
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            res = runner.invoke(cli, ["brief"])
+        assert res.exit_code == 0, res.output
+
+        # answer
+        res = runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        assert res.exit_code == 0, res.output
+
+        # draft
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            res = runner.invoke(cli, ["draft"])
+        assert res.exit_code == 0, res.output
+
+        # review — codex returns APPROVED
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="review body\nGATE: APPROVED"),
+        ):
+            res = runner.invoke(cli, ["review"])
+        assert res.exit_code == 0, res.output
+        assert "APPROVED" in res.output
+
+        # reflection --skip
+        res = runner.invoke(cli, ["reflection", "--skip"])
+        assert res.exit_code == 0, res.output
+
+        # finalize — default now polishes via Claude so review Required-fixes
+        # actually reach the final body. The happy path uses --deterministic
+        # to keep the mocking surface small.
+        res = runner.invoke(cli, ["finalize", "--deterministic"])
+        assert res.exit_code == 0, res.output
+
+        # approve
+        res = runner.invoke(cli, ["approve"])
+        assert res.exit_code == 0, res.output
+
+        # publish
+        res = runner.invoke(cli, ["publish"])
+        assert res.exit_code == 0, res.output
+        post = repo_root / "docs" / "blog" / "posts" / "20260420" / "new.md"
+        assert post.exists()
+        assert "## Intro" in post.read_text(encoding="utf-8")
+
+
+def _write_answers(repo_root: Path) -> str:
+    p = repo_root / "tmp_answers.yaml"
+    p.write_text("answers:\n  q1: because\n", encoding="utf-8")
+    return str(p)
+
+
+def test_review_uses_read_only_sandbox(repo_root: Path):
+    """Issue 1: blogflow review must actually call codex with read-only sandbox."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            [
+                "init",
+                "--topic",
+                "IPv4",
+                "--post-path",
+                "docs/blog/posts/20260420/new.md",
+            ],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+
+        captured: dict = {}
+
+        def _fake_run(self, prompt, *, schema=None, log_dir, stage, extra=None):
+            captured["extra"] = extra
+            return AdapterResult(ok=True, text="ok\nGATE: APPROVED")
+
+        with patch("blogflow.adapters.codex.CodexAdapter.run", new=_fake_run):
+            res = runner.invoke(cli, ["review"])
+        assert res.exit_code == 0, res.output
+        assert captured["extra"] == {"mode": "review"}
+
+
+def test_review_manual_gate_recovers_unclear(repo_root: Path):
+    """Issue 2: after an UNCLEAR review the author can apply a gate manually
+    and the workflow must progress."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            [
+                "init",
+                "--topic",
+                "IPv4",
+                "--post-path",
+                "docs/blog/posts/20260420/new.md",
+            ],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        # Codex answers without a GATE line → UNCLEAR
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="review body without a verdict"),
+        ):
+            res = runner.invoke(cli, ["review"])
+        assert res.exit_code == 0, res.output
+        assert "UNCLEAR" in res.output
+
+        # Status should still be under_review — user hasn't decided yet
+        res = runner.invoke(cli, ["status"])
+        assert "status:   under_review" in res.output
+
+        # Manual override transitions to awaiting_reflection
+        res = runner.invoke(cli, ["review", "--gate", "approved"])
+        assert res.exit_code == 0, res.output
+        assert "APPROVED" in res.output
+
+        res = runner.invoke(cli, ["status"])
+        assert "status:   awaiting_reflection" in res.output
+
+
+def test_review_revise_loops_back_to_draft(repo_root: Path):
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            [
+                "init",
+                "--topic",
+                "IPv4",
+                "--post-path",
+                "docs/blog/posts/20260420/new.md",
+            ],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="review body\nGATE: REVISE"),
+        ):
+            res = runner.invoke(cli, ["review"])
+        assert "REVISE" in res.output
+
+        res = runner.invoke(cli, ["status"])
+        assert "status:   draft_ready" in res.output
+
+
+def test_publish_post_path_override_sets_target(repo_root: Path):
+    """`blogflow init` run without --post-path leaves target_post_path=None;
+    the publish command's --post-path flag must be able to set it retroactively
+    so the author doesn't have to restart the whole workflow."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        # init WITHOUT --post-path (the scenario that previously blocked publish)
+        runner.invoke(cli, ["init", "--topic", "IPv4"])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="ok\nGATE: APPROVED"),
+        ):
+            runner.invoke(cli, ["review"])
+        runner.invoke(cli, ["reflection", "--skip"])
+        runner.invoke(cli, ["finalize", "--deterministic"])
+        runner.invoke(cli, ["approve"])
+
+        # Without the override flag, publish errors out with the usual guard.
+        res = runner.invoke(cli, ["publish"])
+        assert res.exit_code != 0
+        assert "target_post_path" in str(res.exception)
+
+        # With --post-path the target gets set and publish succeeds.
+        target_rel = "docs/blog/posts/20260420-recovery/post.md"
+        res = runner.invoke(cli, ["publish", "--post-path", target_rel])
+        assert res.exit_code == 0, res.output
+        assert (repo_root / target_rel).exists()
+
+
+def test_review_loop_cap_stops_auto_transition(repo_root: Path):
+    """After MAX_AUTO_REVISE auto cycles, a REVISE must NOT transition back to
+    draft — it should park the session and tell the author to pick a manual
+    gate. This is what stops the reviewer/draft loop from burning tokens on
+    non-blocking nits."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/cap/cap.md"],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+
+        # First draft → review (REVISE). Auto-loops once.
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="body\nGATE: REVISE"),
+        ):
+            runner.invoke(cli, ["review"])
+
+        # Second draft → review (REVISE again). Cap fires here.
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="body\nGATE: REVISE"),
+        ):
+            res = runner.invoke(cli, ["review"])
+
+        # Output must nudge toward manual gate; status must stay at under_review
+        # (i.e. NOT loop back to draft_ready).
+        assert "Auto-loop stopped" in res.output
+        assert "--gate" in res.output
+        status_res = runner.invoke(cli, ["status"])
+        assert "status:   under_review" in status_res.output
+
+
+def test_init_auto_increments_on_same_minute_topic(repo_root: Path):
+    """Issue 5: repeated init within the same minute for the same topic must
+    produce distinct session dirs rather than silently reusing one."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        r1 = runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/a/a.md"],
+        )
+        assert r1.exit_code == 0, r1.output
+        r2 = runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/b/b.md"],
+        )
+        assert r2.exit_code == 0, r2.output
+
+        sessions_dir = repo_root / ".blogflow" / "sessions"
+        sessions = sorted(p.name for p in sessions_dir.iterdir() if p.is_dir())
+        assert len(sessions) == 2, sessions
+        assert sessions[0] != sessions[1]
+
+
+def test_editor_flow_splits_env_with_flags(
+    repo_root: Path, tmp_path: Path, monkeypatch
+):
+    """Issue 4: `EDITOR='code --wait'` must not be treated as a single executable name."""
+    from blogflow.commands import reflection as reflection_mod
+
+    # Prime a session so the reflection command can run at awaiting_reflection.
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/a/a.md"],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="ok\nGATE: APPROVED"),
+        ):
+            runner.invoke(cli, ["review"])
+
+        captured: dict = {}
+
+        def fake_run(argv, check=False):
+            captured["argv"] = argv
+            # Simulate the editor writing reflection content into the tmpfile.
+            file_path = Path(argv[-1])
+            file_path.write_text(
+                "# primer comment\n\n내가 배운 것: 네트워크.\n", encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(args=argv, returncode=0)
+
+        monkeypatch.setenv("EDITOR", "code --wait")
+        monkeypatch.setattr(reflection_mod.subprocess, "run", fake_run)
+
+        res = runner.invoke(cli, ["reflection"])
+        assert res.exit_code == 0, res.output
+        assert captured["argv"][:2] == ["code", "--wait"]
+        assert captured["argv"][-1].endswith(".md")
+
+        reflection_path = (
+            repo_root
+            / ".blogflow"
+            / "sessions"
+            / _only_session(repo_root)
+            / "user"
+            / "reflection.md"
+        )
+        assert "내가 배운 것" in reflection_path.read_text(encoding="utf-8")
+
+
+def _only_session(repo_root: Path) -> str:
+    d = repo_root / ".blogflow" / "sessions"
+    dirs = [p for p in d.iterdir() if p.is_dir()]
+    assert len(dirs) == 1, dirs
+    return dirs[0].name
+
+
+def test_status_default_picks_session_saved_last(repo_root: Path):
+    """Finding 1: back-to-back `init` of two different topics used to leave
+    default `blogflow status` pointing at the FIRST session because both
+    sessions' updated_at tied at second precision. The new session must win."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        res_a = runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/a/a.md"],
+        )
+        assert res_a.exit_code == 0, res_a.output
+        res_b = runner.invoke(
+            cli,
+            ["init", "--topic", "IPv6", "--post-path", "docs/blog/posts/b/b.md"],
+        )
+        assert res_b.exit_code == 0, res_b.output
+
+        # No --session supplied → default latest-session resolution.
+        res = runner.invoke(cli, ["status"])
+        assert res.exit_code == 0, res.output
+        assert "IPv6" in res.output, res.output
+        assert "ipv6" in res.output, res.output
+
+
+def test_finalize_defaults_to_regenerate_so_review_is_applied(repo_root: Path):
+    """Finding 2: the default `blogflow finalize` must actually consume the
+    review — not silently concatenate draft + reflection. Previously the
+    deterministic merge was the default and review Required-fixes were dropped.
+    """
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/f/f.md"],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(
+                ok=True,
+                text=(
+                    "### Required fixes (blocking)\n"
+                    "1. Fix the bogus sentence.\n\n"
+                    "### Suggestions (non-blocking)\n"
+                    "- Add more examples.\n\n"
+                    "GATE: APPROVED"
+                ),
+            ),
+        ):
+            runner.invoke(cli, ["review"])
+        runner.invoke(cli, ["reflection", "--skip"])
+
+        # Capture the finalize prompt so we can check that review content
+        # actually reached Claude (i.e. finalize did not fall back to the
+        # deterministic merge that ignores review.md).
+        finalize_calls: list = []
+
+        def _fake_finalize(self, prompt, *, schema=None, log_dir, stage, extra=None):
+            finalize_calls.append({"prompt": prompt, "stage": stage})
+            return AdapterResult(
+                ok=True,
+                text="## Intro\n\nRewritten with required fix applied.\n",
+            )
+
+        with patch("blogflow.adapters.claude.ClaudeAdapter.run", new=_fake_finalize):
+            res = runner.invoke(cli, ["finalize"])
+        assert res.exit_code == 0, res.output
+
+        assert len(finalize_calls) == 1, finalize_calls
+        rendered_prompt = finalize_calls[0]["prompt"]
+        assert "Fix the bogus sentence." in rendered_prompt
+        assert "Required fixes" in rendered_prompt
+
+        final_md = (
+            repo_root
+            / ".blogflow"
+            / "sessions"
+            / _only_session(repo_root)
+            / "outputs"
+            / "final.md"
+        )
+        assert "Rewritten with required fix applied." in final_md.read_text(
+            encoding="utf-8"
+        )
+
+
+def test_finalize_deterministic_flag_skips_claude(repo_root: Path):
+    """Authors can still opt out of the Claude polish — but it must be an
+    explicit choice."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/d/d.md"],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_draft()),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="ok\nGATE: APPROVED"),
+        ):
+            runner.invoke(cli, ["review"])
+        runner.invoke(cli, ["reflection", "--skip"])
+
+        # --deterministic must NOT call Claude.
+        called = {"n": 0}
+
+        def _should_not_be_called(*a, **kw):
+            called["n"] += 1
+            raise AssertionError("claude adapter must not run when --deterministic")
+
+        with patch("blogflow.adapters.claude.ClaudeAdapter.run", new=_should_not_be_called):
+            res = runner.invoke(cli, ["finalize", "--deterministic"])
+        assert res.exit_code == 0, res.output
+        assert called["n"] == 0
+
+
+def test_published_post_has_no_provenance_markers(repo_root: Path):
+    """Finding 3: the published post must not expose `[SUPPORTED:…]` / `[ASSUMED]`
+    audit markers. This covers the `--deterministic` path because that is the
+    code path that currently keeps the raw draft body (no LLM polish), which
+    is where the markers would otherwise survive into the public post."""
+    runner = CliRunner()
+    with patch("blogflow.commands._context.find_repo_root", return_value=repo_root):
+        runner.invoke(
+            cli,
+            ["init", "--topic", "IPv4", "--post-path", "docs/blog/posts/p/p.md"],
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(_ok_brief()),
+        ):
+            runner.invoke(cli, ["brief"])
+        runner.invoke(cli, ["answer", "--file", _write_answers(repo_root)])
+
+        dirty_draft = dict(_ok_draft())
+        dirty_draft["body_markdown"] = (
+            "## Intro\n\n"
+            "IPv4 헤더는 20 바이트이다 [SUPPORTED:RFC 791].\n"
+            "이 주장은 검증되지 않았다 [ASSUMED].\n"
+        )
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run",
+            return_value=_result(dirty_draft),
+        ):
+            runner.invoke(cli, ["draft"])
+        with patch(
+            "blogflow.adapters.codex.CodexAdapter.run",
+            return_value=AdapterResult(ok=True, text="ok\nGATE: APPROVED"),
+        ):
+            runner.invoke(cli, ["review"])
+        runner.invoke(cli, ["reflection", "--skip"])
+        # Use --deterministic so the test does not need to mock Claude again;
+        # the provenance scrub must run on both paths, so this is a strict
+        # regression check on the strip step itself.
+        res = runner.invoke(cli, ["finalize", "--deterministic"])
+        assert res.exit_code == 0, res.output
+
+        final_md = (
+            repo_root
+            / ".blogflow"
+            / "sessions"
+            / _only_session(repo_root)
+            / "outputs"
+            / "final.md"
+        ).read_text(encoding="utf-8")
+        assert "[SUPPORTED:" not in final_md, final_md
+        assert "[ASSUMED]" not in final_md, final_md
+
+        runner.invoke(cli, ["approve"])
+        res = runner.invoke(cli, ["publish"])
+        assert res.exit_code == 0, res.output
+        post = (repo_root / "docs" / "blog" / "posts" / "p" / "p.md").read_text(
+            encoding="utf-8"
+        )
+        assert "[SUPPORTED:" not in post, post
+        assert "[ASSUMED]" not in post, post

--- a/tools/blogflow/tests/test_cli.py
+++ b/tools/blogflow/tests/test_cli.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from blogflow.adapters.base import AdapterResult
@@ -436,6 +437,59 @@ def _only_session(repo_root: Path) -> str:
     dirs = [p for p in d.iterdir() if p.is_dir()]
     assert len(dirs) == 1, dirs
     return dirs[0].name
+
+
+def test_recent_post_titles_skips_posts_without_closing_fence(repo_root: Path):
+    """A post that opens `---` but never closes it must not be accepted — the
+    old parser treated `parts[1]` (the post body!) as YAML and surfaced junk
+    titles. Mirror the strict frontmatter parser and require a closing fence.
+    """
+    from blogflow.commands._context import Context
+    from blogflow.state import SessionStore, load_config
+
+    broken = repo_root / "docs" / "blog" / "posts" / "broken" / "bad.md"
+    broken.parent.mkdir(parents=True, exist_ok=True)
+    broken.write_text(
+        "---\ntitle: Real Title\nlooks like yaml but no closing fence\n",
+        encoding="utf-8",
+    )
+    good = repo_root / "docs" / "blog" / "posts" / "good" / "ok.md"
+    good.parent.mkdir(parents=True, exist_ok=True)
+    good.write_text(
+        "---\ntitle: Good Post\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    ctx = Context(
+        repo_root=repo_root,
+        config=load_config(repo_root),
+        store=SessionStore(repo_root),
+    )
+    titles = ctx.recent_post_titles()
+    assert "Good Post" in titles
+    assert "Real Title" not in titles, (
+        "unclosed frontmatter must not leak through the parser"
+    )
+
+
+def test_build_context_fails_fast_on_malformed_config(repo_root: Path):
+    """A present-but-malformed `.blogflow/config.yaml` used to fall back to
+    defaults silently via a broad `except ConfigError`, so users thought their
+    sandbox/author/blog_dir overrides were in effect while blogflow quietly
+    ignored them. Now the CLI must surface the parse error so it can be fixed.
+    """
+    from blogflow.commands._context import build_context
+    from blogflow.errors import ConfigError
+
+    (repo_root / ".blogflow" / "config.yaml").write_text(
+        "author: bnbong\nblog_dir: [unterminated list\n",
+        encoding="utf-8",
+    )
+    with patch(
+        "blogflow.commands._context.find_repo_root", return_value=repo_root
+    ):
+        with pytest.raises(ConfigError):
+            build_context(repo_root)
 
 
 def test_status_default_picks_session_saved_last(repo_root: Path):

--- a/tools/blogflow/tests/test_cli.py
+++ b/tools/blogflow/tests/test_cli.py
@@ -568,7 +568,9 @@ def test_finalize_deterministic_flag_skips_claude(repo_root: Path):
             called["n"] += 1
             raise AssertionError("claude adapter must not run when --deterministic")
 
-        with patch("blogflow.adapters.claude.ClaudeAdapter.run", new=_should_not_be_called):
+        with patch(
+            "blogflow.adapters.claude.ClaudeAdapter.run", new=_should_not_be_called
+        ):
             res = runner.invoke(cli, ["finalize", "--deterministic"])
         assert res.exit_code == 0, res.output
         assert called["n"] == 0

--- a/tools/blogflow/tests/test_frontmatter.py
+++ b/tools/blogflow/tests/test_frontmatter.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from blogflow import frontmatter as fm_mod
+from blogflow.errors import PublishError
+from blogflow.models import Frontmatter
+
+
+def test_parse_and_dump_roundtrip(sample_post: Path):
+    fm = fm_mod.read(sample_post)
+    assert fm.raw["title"] == "Sample Post"
+    assert fm.body.startswith("Hello, world.")
+    dumped = fm_mod.dump(fm)
+    assert dumped.startswith("---\n")
+    assert "title: Sample Post" in dumped
+    assert "Hello, world." in dumped
+
+
+def test_ensure_published_updates_dates_only():
+    fm = Frontmatter(
+        raw={"date": {"created": "2025-01-01", "updated": "2025-01-01"}},
+        body="",
+    )
+    fm.ensure_published(today=date(2026, 4, 20), ensure_draft_false=True)
+    assert fm.raw["date"]["created"] == "2025-01-01"
+    assert fm.raw["date"]["updated"] == "2026-04-20"
+    assert "draft" not in fm.raw
+
+
+def test_ensure_published_flips_only_when_draft_true():
+    fm = Frontmatter(raw={"draft": True}, body="")
+    fm.ensure_published(today=date(2026, 4, 20), ensure_draft_false=True)
+    assert fm.raw["draft"] is False
+
+
+def test_ensure_published_leaves_date_created_when_missing():
+    fm = Frontmatter(raw={}, body="")
+    fm.ensure_published(today=date(2026, 4, 20), ensure_draft_false=True)
+    assert fm.raw["date"]["created"] == "2026-04-20"
+    assert fm.raw["date"]["updated"] == "2026-04-20"
+
+
+def test_parse_rejects_unclosed_fence():
+    with pytest.raises(PublishError):
+        fm_mod.parse("---\ntitle: x\nbody without fence")
+
+
+def test_write_atomic_overwrites(tmp_path: Path):
+    path = tmp_path / "p.md"
+    path.write_text("---\ntitle: old\n---\n\nbody\n", encoding="utf-8")
+    fm = fm_mod.read(path)
+    fm.raw["title"] = "new"
+    fm_mod.write_atomic(path, fm)
+    assert "title: new" in path.read_text(encoding="utf-8")
+
+
+def test_dump_preserves_key_order():
+    fm = Frontmatter(
+        raw={"title": "t", "date": {"created": "2025-01-01"}, "tags": ["a"]},
+        body="body\n",
+    )
+    text = fm_mod.dump(fm)
+    title_pos = text.find("title:")
+    date_pos = text.find("date:")
+    tags_pos = text.find("tags:")
+    assert 0 <= title_pos < date_pos < tags_pos

--- a/tools/blogflow/tests/test_prompts.py
+++ b/tools/blogflow/tests/test_prompts.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from blogflow import prompts
+from blogflow.models import Brief, BriefQuestion, Draft, Review
+from blogflow.state import Session
+
+
+def _session() -> Session:
+    return Session(
+        id="sid",
+        topic="IPv4",
+        slug="ipv4",
+        target_post_path="docs/blog/posts/x/x.md",
+    )
+
+
+def _brief() -> Brief:
+    return Brief(
+        goal="Understand IPv4",
+        learning_brief="IPv4 basics",
+        source_pack=[{"label": "RFC791", "url": "https://rfc/791", "note": "spec"}],
+        scope="in: header; out: v6",
+        questions=[BriefQuestion(id="q1", text="Why now?", why="Context")],
+        outline=["Intro", "Header"],
+        claim_categories=["spec"],
+    )
+
+
+def _draft() -> Draft:
+    return Draft(
+        title_candidates=["IPv4 Intro"],
+        description_candidates=["Learn IPv4 basics."],
+        body_markdown="## Intro\n\nHello. [SUPPORTED:RFC791]\n",
+        claim_summary=[
+            {
+                "claim": "IP header is 20 bytes",
+                "status": "SUPPORTED",
+                "source": "RFC791",
+            }
+        ],
+        references=[{"label": "RFC791", "url": "https://rfc/791"}],
+        known_risks=["watch for length"],
+    )
+
+
+def test_ideas_template_renders(repo_root: Path):
+    text = prompts.render(
+        "ideas",
+        {
+            "author": "bnbong",
+            "default_category": "CS",
+            "category": "Network",
+            "count": 5,
+            "recent_titles": ["A", "B"],
+        },
+        repo_root,
+    )
+    assert "bnbong" in text
+    assert "Network" in text
+
+
+def test_brief_template_renders(repo_root: Path):
+    text = prompts.render(
+        "brief",
+        {
+            "author": "bnbong",
+            "default_category": "CS",
+            "session": _session(),
+            "recent_titles": [],
+        },
+        repo_root,
+    )
+    assert "IPv4" in text
+    assert "JSON" in text
+
+
+def test_draft_template_renders(repo_root: Path):
+    text = prompts.render(
+        "draft",
+        {
+            "author": "bnbong",
+            "session": _session(),
+            "brief": _brief(),
+            "answers": {"q1": "Because of IPv4 exhaustion."},
+        },
+        repo_root,
+    )
+    assert "IPv4 exhaustion" in text
+    assert "RFC791" in text
+
+
+def test_draft_template_embeds_review_feedback_on_revise_loop(repo_root: Path):
+    """When a revise loop feeds the previous review into draft, the template
+    must surface it — otherwise the rewrite ignores the reviewer and just
+    regenerates the same draft. We intentionally do NOT pass the prior draft
+    back to keep revise-loop input tokens bounded."""
+    session = _session()
+    session.review_gate = "revise"
+    text = prompts.render(
+        "draft",
+        {
+            "author": "bnbong",
+            "session": session,
+            "brief": _brief(),
+            "answers": {"q1": "A."},
+            "prior_review": "- claim X is unsourced\nGATE: REVISE",
+        },
+        repo_root,
+    )
+    assert "Reviewer feedback" in text
+    assert "claim X is unsourced" in text
+    assert "GATE: REVISE" in text
+    assert "Required-fixes" in text or "Required fixes" in text
+
+
+def test_review_template_biases_toward_approved(repo_root: Path):
+    """Reviewer prompt must frame APPROVED as the default outcome, not the
+    exception — otherwise the gate always flips to REVISE on stylistic nits."""
+    text = prompts.render(
+        "review",
+        {
+            "author": "bnbong",
+            "session": _session(),
+            "brief": _brief(),
+            "draft": _draft(),
+        },
+        repo_root,
+    )
+    # default/expected APPROVED wording
+    assert "default" in text.lower()
+    # non-blocking categories are spelled out
+    assert "Suggestions" in text
+    # the three blocking categories are named
+    assert "Hallucination" in text
+    assert "Factually wrong" in text
+
+
+def test_review_template_includes_gate_instruction(repo_root: Path):
+    text = prompts.render(
+        "review",
+        {
+            "author": "bnbong",
+            "session": _session(),
+            "brief": _brief(),
+            "draft": _draft(),
+        },
+        repo_root,
+    )
+    assert "GATE: APPROVED" in text
+    assert "GATE: REVISE" in text
+    assert "GATE: BLOCK" in text
+
+
+def test_finalize_template_applies_only_required_fixes_and_strips_markers(repo_root: Path):
+    """The finalize template must (a) apply Required-fixes only (mirror the
+    draft revise-loop rule so suggestions don't get silently applied) and
+    (b) instruct Claude to strip `[SUPPORTED:…]` / `[ASSUMED]` markers so they
+    never leak into the published body."""
+    review = Review(raw="(review body)", gate="approved")
+    text = prompts.render(
+        "finalize",
+        {
+            "author": "bnbong",
+            "session": _session(),
+            "brief": _brief(),
+            "draft": _draft(),
+            "review": review,
+            "reflection": "",
+        },
+        repo_root,
+    )
+    lowered = text.lower()
+    # Required-fixes applied; Suggestions ignored.
+    assert "required fixes" in lowered
+    assert "ignore" in lowered and "suggestions" in lowered
+    # Strip provenance markers.
+    assert "[SUPPORTED:" in text  # literal marker referenced in instructions
+    assert "[ASSUMED]" in text
+    assert "strip" in lowered or "remove" in lowered
+
+
+def test_finalize_template_renders_with_and_without_reflection(repo_root: Path):
+    review = Review(raw="review text", gate="approved")
+    text_with = prompts.render(
+        "finalize",
+        {
+            "author": "bnbong",
+            "session": _session(),
+            "brief": _brief(),
+            "draft": _draft(),
+            "review": review,
+            "reflection": "I learned X.",
+        },
+        repo_root,
+    )
+    assert "I learned X." in text_with
+    assert "회고" in text_with
+
+    text_without = prompts.render(
+        "finalize",
+        {
+            "author": "bnbong",
+            "session": _session(),
+            "brief": _brief(),
+            "draft": _draft(),
+            "review": review,
+            "reflection": "",
+        },
+        repo_root,
+    )
+    assert "skip" in text_without.lower() or "(" in text_without
+
+
+def test_reflection_template_renders(repo_root: Path):
+    text = prompts.render(
+        "reflection",
+        {"author": "bnbong", "session": _session()},
+        repo_root,
+    )
+    assert "IPv4" in text
+
+
+def test_user_override_wins(repo_root: Path):
+    override_dir = repo_root / ".blogflow" / "prompts"
+    override_dir.mkdir(parents=True, exist_ok=True)
+    (override_dir / "ideas.md.j2").write_text("OVERRIDE {{ author }}", encoding="utf-8")
+    text = prompts.render(
+        "ideas",
+        {
+            "author": "bnbong",
+            "default_category": "CS",
+            "category": None,
+            "count": 3,
+            "recent_titles": [],
+        },
+        repo_root,
+    )
+    assert text.startswith("OVERRIDE bnbong")

--- a/tools/blogflow/tests/test_prompts.py
+++ b/tools/blogflow/tests/test_prompts.py
@@ -153,7 +153,9 @@ def test_review_template_includes_gate_instruction(repo_root: Path):
     assert "GATE: BLOCK" in text
 
 
-def test_finalize_template_applies_only_required_fixes_and_strips_markers(repo_root: Path):
+def test_finalize_template_applies_only_required_fixes_and_strips_markers(
+    repo_root: Path,
+):
     """The finalize template must (a) apply Required-fixes only (mirror the
     draft revise-loop rule so suggestions don't get silently applied) and
     (b) instruct Claude to strip `[SUPPORTED:…]` / `[ASSUMED]` markers so they

--- a/tools/blogflow/tests/test_publish.py
+++ b/tools/blogflow/tests/test_publish.py
@@ -111,3 +111,80 @@ def test_suggested_git_commands_format(tmp_path: Path):
     assert any(c.startswith("git add ") for c in cmds)
     assert any("git commit -m" in c for c in cmds)
     assert any("git push" in c for c in cmds)
+
+
+def test_suggested_git_commands_uses_detected_branch(tmp_path: Path, monkeypatch):
+    """The push hint must not hardcode a branch — detect whichever branch the
+    repo is currently on, or fall back to a bare `git push` if detection fails.
+    Hardcoding `master` misled users on repos whose default is `main`."""
+    import subprocess as sp
+
+    captured: dict = {}
+
+    def fake_run(argv, capture_output=False, text=False, timeout=None, check=False):
+        captured["argv"] = argv
+        return sp.CompletedProcess(args=argv, returncode=0, stdout="feature-x\n", stderr="")
+
+    monkeypatch.setattr(P.subprocess, "run", fake_run)
+    cmds = P.suggested_git_commands(
+        Path("docs/blog/posts/x.md"),
+        ".blogflow/sessions/abc",
+        repo_root=tmp_path,
+    )
+    assert "git push origin feature-x" in cmds, cmds
+    # Must have invoked `git rev-parse --abbrev-ref HEAD` on the given root.
+    assert "rev-parse" in captured["argv"]
+    assert str(tmp_path) in captured["argv"]
+
+
+def test_suggested_git_commands_falls_back_when_branch_detection_fails(
+    tmp_path: Path, monkeypatch
+):
+    """Detached HEAD / non-git dir / git missing must not produce a misleading
+    push hint — emit bare `git push` so the user's own tracking config applies."""
+    import subprocess as sp
+
+    def fake_run(argv, capture_output=False, text=False, timeout=None, check=False):
+        return sp.CompletedProcess(args=argv, returncode=0, stdout="HEAD\n", stderr="")
+
+    monkeypatch.setattr(P.subprocess, "run", fake_run)
+    cmds = P.suggested_git_commands(
+        Path("docs/blog/posts/x.md"),
+        ".blogflow/sessions/abc",
+        repo_root=tmp_path,
+    )
+    assert "git push" in cmds
+    # No `origin master` / `origin main` hardcoded.
+    assert not any("origin master" in c or "origin main" in c for c in cmds)
+
+
+def test_validate_post_path_honors_configured_blog_dir(repo_root: Path):
+    """Config supports `blog_dir`; path validation must reject/accept based on
+    that config value rather than always forcing `docs/blog/posts/`."""
+    custom = repo_root / "content" / "blog"
+    custom.mkdir(parents=True)
+    # Default blog_dir rejects a path under /content/blog
+    with pytest.raises(PublishError):
+        P.validate_post_path(repo_root, "content/blog/post.md")
+    # With blog_dir override, the same path validates cleanly.
+    assert P.validate_post_path(
+        repo_root, "content/blog/post.md", "content/blog"
+    ) == (repo_root / "content/blog/post.md").resolve()
+
+
+def test_merge_final_respects_update_updated_date_false(sample_post: Path):
+    """config.publish.update_updated_date = false used to be a silent no-op;
+    now it must actually prevent touching the `date.updated` field."""
+    P.merge_final_into_post(
+        sample_post,
+        "## kept\n",
+        today=date(2026, 4, 20),
+        ensure_draft_false=True,
+        topic="Sample Post",
+        author="bnbong",
+        update_updated_date=False,
+    )
+    text = sample_post.read_text(encoding="utf-8")
+    # The fixture ships with updated: 2025-01-01 — it must stay put.
+    assert "2025-01-01" in text
+    assert "2026-04-20" not in text

--- a/tools/blogflow/tests/test_publish.py
+++ b/tools/blogflow/tests/test_publish.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from blogflow import publish as P
+from blogflow.errors import PublishError
+
+
+def test_validate_post_path_accepts_blog_post(repo_root: Path):
+    rel = "docs/blog/posts/20250101/new.md"
+    result = P.validate_post_path(repo_root, rel)
+    assert result == (repo_root / rel).resolve()
+
+
+def test_validate_post_path_rejects_escape(repo_root: Path):
+    with pytest.raises(PublishError):
+        P.validate_post_path(repo_root, "../outside.md")
+
+
+def test_validate_post_path_rejects_non_md(repo_root: Path):
+    with pytest.raises(PublishError):
+        P.validate_post_path(repo_root, "docs/blog/posts/foo.txt")
+
+
+def test_validate_post_path_rejects_non_blog(repo_root: Path):
+    with pytest.raises(PublishError):
+        P.validate_post_path(repo_root, "docs/index.md")
+
+
+def test_merge_final_creates_skeleton(repo_root: Path):
+    target = repo_root / "docs" / "blog" / "posts" / "20260420" / "new.md"
+    P.merge_final_into_post(
+        target,
+        "## Intro\n\nHello.\n",
+        today=date(2026, 4, 20),
+        ensure_draft_false=True,
+        topic="New Post",
+        author="bnbong",
+    )
+    text = target.read_text(encoding="utf-8")
+    assert "title: New Post" in text
+    assert "## Intro" in text
+    assert "created: '2026-04-20'" in text or "created: 2026-04-20" in text
+
+
+def test_merge_final_updates_existing(sample_post: Path):
+    P.merge_final_into_post(
+        sample_post,
+        "## Updated\n\nrewritten.\n",
+        today=date(2026, 4, 20),
+        ensure_draft_false=True,
+        topic="Sample Post",
+        author="bnbong",
+    )
+    text = sample_post.read_text(encoding="utf-8")
+    assert "## Updated" in text
+    assert "Hello, world." not in text
+    assert "created: 2025-01-01" in text or "created: '2025-01-01'" in text
+    assert "updated: '2026-04-20'" in text or "updated: 2026-04-20" in text
+
+
+def test_guard_publish_requires_approved():
+    with pytest.raises(PublishError):
+        P.guard_publish(
+            status="final_ready",
+            expected_status="approved",
+            target_post_path="docs/blog/posts/x.md",
+            final_path=Path("/nonexistent"),
+        )
+
+
+def test_guard_publish_requires_target(tmp_path: Path):
+    final = tmp_path / "final.md"
+    final.write_text("body", encoding="utf-8")
+    with pytest.raises(PublishError):
+        P.guard_publish(
+            status="approved",
+            expected_status="approved",
+            target_post_path=None,
+            final_path=final,
+        )
+
+
+def test_strip_provenance_markers_removes_supported_and_assumed():
+    """Final.md / published posts must never expose internal `[SUPPORTED:<label>]`
+    or `[ASSUMED]` tags to readers — they are audit markers used only between
+    draft and review stages."""
+    from blogflow.commands.finalize import strip_provenance_markers
+
+    raw = (
+        "IPv4 헤더는 기본 20 바이트이다 [SUPPORTED:RFC 791].\n"
+        "이 주장은 아직 검증되지 않았다 [ASSUMED].\n"
+        "여러 태그가 한 문단에 섞여도 [SUPPORTED:IANA] [ASSUMED] 제거된다.\n"
+    )
+    cleaned = strip_provenance_markers(raw)
+    assert "[SUPPORTED:" not in cleaned
+    assert "[ASSUMED]" not in cleaned
+    # Prose must still read naturally — no double spaces or orphan punctuation.
+    assert "20 바이트이다." in cleaned
+    assert "검증되지 않았다." in cleaned
+    assert "한 문단에 섞여도 제거된다." in cleaned
+
+
+def test_suggested_git_commands_format(tmp_path: Path):
+    cmds = P.suggested_git_commands(
+        Path("docs/blog/posts/x.md"), ".blogflow/sessions/abc"
+    )
+    assert any(c.startswith("git add ") for c in cmds)
+    assert any("git commit -m" in c for c in cmds)
+    assert any("git push" in c for c in cmds)

--- a/tools/blogflow/tests/test_state.py
+++ b/tools/blogflow/tests/test_state.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from blogflow import state as S
+from blogflow.errors import StateError
+
+
+def test_slugify_handles_korean_and_specials():
+    assert S.slugify("Hello IPv4 — intro!") == "hello-ipv4-intro"
+    assert S.slugify("네트워크 3장") == "네트워크-3장"
+    assert S.slugify("  ") == "post"
+
+
+def test_session_id_format():
+    sid = S.new_session_id("IPv4")
+    assert "-ipv4" in sid
+    assert len(sid.split("-")[0]) == 8  # YYYYMMDD
+
+
+def test_transition_allowed_and_denied():
+    s = S.Session(id="x", topic="x", slug="x")
+    S.transition(s, S.STATUS_BRIEF_READY)
+    assert s.status == S.STATUS_BRIEF_READY
+    S.transition(s, S.STATUS_AWAITING_ANSWERS)
+    with pytest.raises(StateError) as exc:
+        S.transition(s, S.STATUS_PUBLISHED)
+    assert exc.value.expected_command == S.NEXT_COMMAND_HINT[S.STATUS_AWAITING_ANSWERS]
+
+
+def test_transition_self_is_noop():
+    s = S.Session(id="x", topic="x", slug="x", status=S.STATUS_DRAFT_READY)
+    S.transition(s, S.STATUS_DRAFT_READY)
+    assert s.status == S.STATUS_DRAFT_READY
+
+
+def test_session_store_roundtrip(tmp_path: Path):
+    store = S.SessionStore(tmp_path)
+    s = S.Session(
+        id="sid", topic="IPv4", slug="ipv4", target_post_path="docs/blog/posts/x.md"
+    )
+    store.create(s)
+    loaded = store.load("sid")
+    assert loaded.topic == "IPv4"
+    assert loaded.target_post_path == "docs/blog/posts/x.md"
+    assert store.list_sessions() == ["sid"]
+
+
+def test_session_store_resolve_latest(tmp_path: Path):
+    store = S.SessionStore(tmp_path)
+    s1 = S.Session(id="a", topic="t1", slug="t1", updated_at="2026-04-20T10:00:00")
+    s2 = S.Session(id="b", topic="t2", slug="t2", updated_at="2026-04-20T10:00:01")
+    store.create(s1)
+    store.create(s2)
+    # re-save with fixed updated_at since create()/save() overrides updated_at
+    s1.updated_at = "2026-04-20T10:00:00"
+    store.session_file(s1.id).write_text(
+        __import__("yaml").safe_dump(s1.to_dict(), sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    s2.updated_at = "2026-04-20T10:00:05"
+    store.session_file(s2.id).write_text(
+        __import__("yaml").safe_dump(s2.to_dict(), sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    latest = store.resolve_latest()
+    assert latest.id == "b"
+
+
+def test_find_repo_root_finds_config(repo_root: Path):
+    nested = repo_root / "docs" / "deep"
+    nested.mkdir(parents=True, exist_ok=True)
+    assert S.find_repo_root(nested) == repo_root
+
+
+def test_next_hint_matches_actual_command_for_each_state():
+    """Issue 3: the hint for each state must match the command whose state-gate
+    accepts that state. Happy-path users should be able to follow `next: ...`
+    without the CLI then refusing with a state-mismatch error."""
+    expected = {
+        S.STATUS_INITIATED: "blogflow brief",
+        S.STATUS_AWAITING_ANSWERS: "blogflow answer",
+        S.STATUS_DRAFT_READY: "blogflow draft",
+        S.STATUS_UNDER_REVIEW: "blogflow review",
+        S.STATUS_AWAITING_REFLECTION: "blogflow reflection",
+        S.STATUS_FINAL_READY: "blogflow finalize",
+        S.STATUS_APPROVED: "blogflow publish",
+    }
+    for status, hint in expected.items():
+        assert S.NEXT_COMMAND_HINT[status] == hint, f"wrong hint for {status}"
+
+
+def test_new_session_id_autoincrements_on_collision():
+    """Issue 5: same-minute same-topic must not collide."""
+    from datetime import datetime
+
+    now = datetime(2026, 4, 20, 10, 30)
+    existing = {"20260420-1030-ipv4"}
+    sid = S.new_session_id("IPv4", now=now, existing=existing)
+    assert sid == "20260420-1030-ipv4-2"
+
+    existing.add("20260420-1030-ipv4-2")
+    sid2 = S.new_session_id("IPv4", now=now, existing=existing)
+    assert sid2 == "20260420-1030-ipv4-3"
+
+
+def test_session_store_create_raises_on_duplicate(tmp_path: Path):
+    """Issue 5: create() must refuse to silently reuse an existing session dir."""
+    store = S.SessionStore(tmp_path)
+    s = S.Session(id="dup", topic="t", slug="t")
+    store.create(s)
+    with pytest.raises(StateError):
+        store.create(S.Session(id="dup", topic="t", slug="t"))
+
+
+def test_session_store_resolve_latest_picks_newer_within_same_second(tmp_path: Path):
+    """Two sessions saved in the same wall-clock second used to tie on
+    updated_at (seconds precision) and resolve_latest returned whichever came
+    first alphabetically. With microsecond precision plus created_at/id
+    tie-breakers, the session that was actually saved *later* must win so
+    that switching to a new topic does not accidentally reuse the old session.
+    """
+    store = S.SessionStore(tmp_path)
+    s_a = S.Session(id="20260420-2122-ipv4", topic="IPv4", slug="ipv4")
+    s_b = S.Session(id="20260420-2122-ipv6", topic="IPv6", slug="ipv6")
+    store.create(s_a)
+    # store.save() writes the real, current timestamp — so creating s_b after
+    # s_a guarantees s_b.updated_at > s_a.updated_at at microsecond precision.
+    store.create(s_b)
+    assert store.resolve_latest().id == s_b.id
+
+    # Flip the creation order: the session created second must still win.
+    tmp_path_2 = tmp_path / "alt"
+    tmp_path_2.mkdir()
+    store2 = S.SessionStore(tmp_path_2)
+    t_b = S.Session(id="20260420-2122-ipv6", topic="IPv6", slug="ipv6")
+    t_a = S.Session(id="20260420-2122-ipv4", topic="IPv4", slug="ipv4")
+    store2.create(t_b)
+    store2.create(t_a)
+    assert store2.resolve_latest().id == t_a.id
+
+
+def test_session_store_resolve_latest_tiebreak_on_identical_timestamps(tmp_path: Path):
+    """Belt-and-suspenders: if even microsecond updated_at somehow ties, the
+    tie-breaker on created_at (and then id) keeps the selection deterministic."""
+    store = S.SessionStore(tmp_path)
+    s1 = S.Session(
+        id="20260420-2122-a",
+        topic="a",
+        slug="a",
+        created_at="2026-04-20T21:22:00.000100",
+        updated_at="2026-04-20T21:22:30.555555",
+    )
+    s2 = S.Session(
+        id="20260420-2122-b",
+        topic="b",
+        slug="b",
+        created_at="2026-04-20T21:22:00.000500",
+        updated_at="2026-04-20T21:22:30.555555",
+    )
+    store.create(s1)
+    store.create(s2)
+    import yaml as _yaml
+
+    # Overwrite updated_at after create() so they genuinely tie.
+    for s in (s1, s2):
+        store.session_file(s.id).write_text(
+            _yaml.safe_dump(s.to_dict(), sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+    # s2 has later created_at, so it must win.
+    assert store.resolve_latest().id == s2.id

--- a/tools/blogflow/uv.lock
+++ b/tools/blogflow/uv.lock
@@ -1,0 +1,337 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "blogflow"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "jinja2" },
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.1" },
+    { name = "jinja2", specifier = ">=3.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary

Add `blogflow`, a local-first CLI for drafting and publishing technical blog posts with human approval gates.

This PR introduces a structured editorial workflow for `bnbong.github.io` that coordinates:
- Claude for briefing, drafting, and finalization
- Codex for review
- author approval before publish

The goal is to make technical posting repeatable without turning the workflow into fully automatic publishing.

## What’s included

- New `tools/blogflow` Python CLI package
- Stateful workflow commands:
  - `ideas`
  - `init`
  - `status`
  - `brief`
  - `answer`
  - `draft`
  - `review`
  - `reflection`
  - `finalize`
  - `approve`
  - `publish`
- Session persistence under `.blogflow/sessions/`
- Claude / Codex adapter layer
- Prompt templates for each workflow stage
- Frontmatter / publish helpers
- Regression tests for:
  - state transitions
  - latest-session resolution
  - review gate handling
  - finalize behavior
  - provenance marker stripping
  - publish safeguards

## Why

The existing blog workflow made it hard to sustain frequent technical posting while keeping me deeply involved in:
- topic selection
- source validation
- article structure
- final approval

`blogflow` is designed to solve that with:
- explicit review / approval stages
- source-aware drafting
- Codex review integration
- local-only execution on macOS

## Validation

Tested with:

```bash
pytest tools/blogflow/tests -q
```

Also manually validated with a real IPv4 post workflow:

- session creation
- draft generation
- Codex review
- finalization
- publish flow

## Notes for review

Please focus on:

- state machine correctness
- multi-session safety
- finalize / publish safety
- reviewer workflow UX
- maintainability of prompts and adapters